### PR TITLE
fix: Use pubdate for video publication time (BiliBili)

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliRelatedInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliRelatedInfoItemExtractor.java
@@ -38,7 +38,7 @@ public class BilibiliRelatedInfoItemExtractor implements StreamInfoItemExtractor
         type = "related";
         id = item.getString("bvid").equals("") ? utils.av2bv(item.getLong("aid")) : item.getString("bvid");
         pic = item.getString("pic").replace("http", "https");
-        pubdate = item.getLong("ctime");
+        pubdate = item.getLong("pubdate");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BillibiliStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BillibiliStreamExtractor.java
@@ -578,7 +578,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
         if (isPremiumContent == 1) {
             return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(watch.getLong("pub_time") * 1000));
         }
-        return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(watch.getLong("ctime") * 1000));
+        return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date(watch.getLong("pubdate") * 1000));
     }
 
     @Override
@@ -661,7 +661,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
             for (int i = 0; i < partitionData.size(); i++) {
                 collector.commit(
                         new BilibiliRelatedInfoItemExtractor(
-                                partitionData.getObject(i), bvid, getThumbnailUrl(), String.valueOf(i + 1), getUploaderName(), watch.getLong("ctime")));
+                                partitionData.getObject(i), bvid, getThumbnailUrl(), String.valueOf(i + 1), getUploaderName(), watch.getLong("pubdate")));
             }
         } catch (ParsingException e) {
             e.printStackTrace();


### PR DESCRIPTION
The extractor was previously using the `ctime` field for determining a video's publication date. However, analysis of the Bilibili API shows that `ctime` represents the creation time of the data entry and can be unreliable, often showing June 2017 for older videos.

This commit changes the implementation to use the `pubdate` field instead.

See: https://github.com/SocialSisterYi/bilibili-API-collect/issues/306