### PR TITLE
fix(extractor/bilibili): update paid content extractor

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliService.java
@@ -77,7 +77,7 @@ public class BilibiliService extends StreamingService {
     public static final String LIVE_REFERER = "https://live.bilibili.com/";
 
     public static String FREE_VIDEO_BASE_URL = "https://api.bilibili.com/x/player/wbi/playurl";
-    public static String PAID_VIDEO_BASE_URL = "https://api.bilibili.com/pgc/player/web/playurl";
+    public static String PAID_VIDEO_BASE_URL = "https://api.bilibili.com/pgc/player/web/v2/playurl";
     public static String LIVE_BASE_URL = "live.bilibili.com";
     public static String QUERY_VIDEO_BULLET_COMMENTS_URL = "https://api.bilibili.com/x/v1/dm/list.so?oid=";
     public static String QUERY_USER_INFO_URL = "https://api.bilibili.com/x/web-interface/card?photo=true&mid=";

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/utils.java
@@ -213,9 +213,7 @@ public class utils {
 
         params.put("w_rid", wbiResults[0]);
         params.put("wts", wbiResults[1]);
-        return baseUrl + "?" + params.entrySet().stream()
-                .map(e -> e.getKey() + "=" + e.getValue())
-                .collect(Collectors.joining("&"));
+        return baseUrl + "?" + createQueryString(params);
     }
 
     public static String getRecordApiUrl(String url) {
@@ -379,6 +377,12 @@ public class utils {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static String createQueryString(Map<String, String> params) {
+        return params.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining("&"));
     }
 
     private static String createQueryStringWithPercentSpace(Map<String, String> params) {


### PR DESCRIPTION
Bilibili has updated its API for fetching premium video streams. This commit adapts the extractor to these changes.

- The `PAID_VIDEO_BASE_URL` is updated to the new `v2` endpoint.
- WBI signing is now skipped for paid content requests as the endpoint does not require it.
- JSON parsing is adjusted to match the updated response structure for paid videos.
- A `createQueryString` utility function has been added for cleaner URL parameter construction.

Fixes https://github.com/InfinityLoop1308/PipePipe/issues/1348