### PR TITLE
fix(bilibili): correctly extract video owner names

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelExtractor.java
@@ -224,7 +224,7 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
                 JsonArray results
         ) throws ParsingException {
             for (int i = 0; i < results.size(); i++) {
-                collector.commit(new BilibiliChannelInfoItemClientAPIExtractor(results.getObject(i), extractor.getName(), extractor.getAvatarUrl()));
+                collector.commit(new BilibiliChannelInfoItemClientAPIExtractor(results.getObject(i), extractor.getAvatarUrl()));
             }
         }
 
@@ -312,7 +312,7 @@ public class BilibiliChannelExtractor extends ChannelExtractor {
                 JsonArray results
         ) throws ParsingException {
             for (int i = 0; i < results.size(); i++) {
-                collector.commit(new BilibiliChannelInfoItemWebAPIExtractor(results.getObject(i), extractor.getName(), extractor.getAvatarUrl()));
+                collector.commit(new BilibiliChannelInfoItemWebAPIExtractor(results.getObject(i), null, null));
             }
         }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemClientAPIExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemClientAPIExtractor.java
@@ -20,12 +20,10 @@ import java.util.Optional;
 public class BilibiliChannelInfoItemClientAPIExtractor implements StreamInfoItemExtractor {
 
     protected final JsonObject item;
-    public String name;
-    public String face;
+    private final String face;
 
-    public BilibiliChannelInfoItemClientAPIExtractor(final JsonObject json, String name, String face) {
+    public BilibiliChannelInfoItemClientAPIExtractor(final JsonObject json, String face) {
         item = json;
-        this.name = name;
         this.face = face;
     }
 
@@ -64,7 +62,7 @@ public class BilibiliChannelInfoItemClientAPIExtractor implements StreamInfoItem
 
     @Override
     public String getUploaderName() throws ParsingException {
-        return name;
+        return item.getString("author");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemWebAPIExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemWebAPIExtractor.java
@@ -19,8 +19,8 @@ import static org.schabi.newpipe.extractor.services.bilibili.utils.getDurationFr
 public class BilibiliChannelInfoItemWebAPIExtractor implements StreamInfoItemExtractor {
 
     protected final JsonObject item;
-    public String name;
-    public String face;
+    private final String name;
+    private final String face;
 
     public BilibiliChannelInfoItemWebAPIExtractor(final JsonObject json, String name, String face) {
         item = json;
@@ -63,7 +63,7 @@ public class BilibiliChannelInfoItemWebAPIExtractor implements StreamInfoItemExt
 
     @Override
     public String getUploaderName() throws ParsingException {
-        return name;
+        return Optional.of(item.getString("author")).orElse(name);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliPlaylistExtractor.java
@@ -97,7 +97,7 @@ public class BilibiliPlaylistExtractor extends PlaylistExtractor {
         }
         final StreamInfoItemsCollector collector = new StreamInfoItemsCollector(getServiceId());
         for (int i = 0; i < results.size(); i++) {
-            collector.commit(new BilibiliChannelInfoItemWebAPIExtractor(results.getObject(i), page.getUrl().split("username=")[1], null));
+            collector.commit(new BilibiliChannelInfoItemWebAPIExtractor(results.getObject(i), getUploaderName(), getUploaderAvatarUrl()));
         }
         return new InfoItemsPage<>(collector, new Page(utils.getNextPageFromCurrentUrl(page.getUrl(), type.equals("seasons_archives") ? "page_num" : "pn", 1), getDefaultCookies()));
     }


### PR DESCRIPTION
The previous implementation incorrectly used the channels owner name as the uploader for all videos within that channel or playlist. This was because the channel extractor was passing its own name to the video info item extractors.

This commit fixes the issue by:
- Modifying the `BilibiliChannelInfoItemClientAPIExtractor` and `BilibiliChannelInfoItemWebAPIExtractor` to extract the uploader name from the videos own data.
- Correctly passing the uploaders name and avatar to the `BilibiliChannelInfoItemWebAPIExtractor` in the `BilibiliPlaylistExtractor.