### PR TITLE
refactor: simplify Bilibili URL construction

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemClientAPIExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemClientAPIExtractor.java
@@ -36,7 +36,7 @@ public class BilibiliChannelInfoItemClientAPIExtractor implements StreamInfoItem
 
     @Override
     public String getUrl() throws ParsingException {
-        return "https://www.bilibili.com/video/" + item.getString("bvid") + "?p=1";
+        return "https://www.bilibili.com/video/" + item.getString("bvid");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemWebAPIExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelInfoItemWebAPIExtractor.java
@@ -35,7 +35,7 @@ public class BilibiliChannelInfoItemWebAPIExtractor implements StreamInfoItemExt
 
     @Override
     public String getUrl() throws ParsingException {
-        return "https://www.bilibili.com/video/" + item.getString("bvid") + "?p=1";
+        return "https://www.bilibili.com/video/" + item.getString("bvid");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliRecommendedVideosInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliRecommendedVideosInfoItemExtractor.java
@@ -29,7 +29,7 @@ public class BilibiliRecommendedVideosInfoItemExtractor implements StreamInfoIte
 
     @Override
     public String getUrl() throws ParsingException {
-        return item.getString("uri") + "?p=1";
+        return item.getString("uri");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliRelatedInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliRelatedInfoItemExtractor.java
@@ -14,6 +14,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Objects;
 
+import static org.schabi.newpipe.extractor.services.bilibili.utils.createUrlWithPage;
+
 public class BilibiliRelatedInfoItemExtractor implements StreamInfoItemExtractor {
 
     protected final JsonObject item;
@@ -51,7 +53,7 @@ public class BilibiliRelatedInfoItemExtractor implements StreamInfoItemExtractor
 
     @Override
     public String getUrl() throws ParsingException {
-        return "https://www.bilibili.com/video/" + id + "?p=" + p;
+        return createUrlWithPage("https://www.bilibili.com/video/" + id, p);
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliTrendingInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliTrendingInfoItemExtractor.java
@@ -29,7 +29,7 @@ public class BilibiliTrendingInfoItemExtractor implements StreamInfoItemExtracto
 
     @Override
     public String getUrl() throws ParsingException {
-        return "https://www.bilibili.com/video/" + item.getString("bvid") + "?p=1";
+        return "https://www.bilibili.com/video/" + item.getString("bvid");
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/linkHandler/BilibiliStreamLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/linkHandler/BilibiliStreamLinkHandlerFactory.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.services.bilibili.BilibiliService;
 import org.schabi.newpipe.extractor.services.bilibili.utils;
 
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.LIVE_BASE_URL;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.createUrlWithPage;
 
 /*
 General form of stream link url: https://m.bilibili.com/video/<ID> (mobile) and https://www.bilibili.com/video/<ID> (PC)
@@ -48,16 +49,16 @@ public class BilibiliStreamLinkHandlerFactory extends LinkHandlerFactory {
 
         if (url.split("/")[url.split("/").length - 1].startsWith("BV")) {
             String parseResult = url.split(Pattern.quote("/BV"))[1].split("\\?")[0].split("/")[0];
-            url = "BV" + parseResult + "?p=" + p;
+            url = createUrlWithPage("BV" + parseResult, p);
         } else if (url.contains("bvid=")) {
             String parseResult = url.split(Pattern.quote("bvid="))[1].split("&")[0];
-            url = parseResult + "?p=" + p;
+            url = createUrlWithPage(parseResult, p);
         } else if (url.split("/")[url.split("/").length - 1].startsWith("av")) {
             String parseResult = url.split(Pattern.quote("av"))[1].split("\\?")[0];
-            url = utils.av2bv(Long.parseLong(parseResult)) + "?p=" + p;
+            url = createUrlWithPage(utils.av2bv(Long.parseLong(parseResult)), p);
         } else if (url.contains("aid=")) {
             String parseResult = url.split(Pattern.quote("aid="))[1].split("&")[0];
-            url = utils.av2bv(Long.parseLong(parseResult)) + "?p=" + p;
+            url = createUrlWithPage(utils.av2bv(Long.parseLong(parseResult)), p);
         } else if (url.contains(LIVE_BASE_URL) || url.contains("bangumi/play/")) {
             url = url.split("/")[url.split("/").length - 1].split("\\?")[0];
         } else {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/utils.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/utils.java
@@ -372,6 +372,10 @@ public class utils {
         return le.substring(0, 32);
     }
 
+    public static String createUrlWithPage(String url, String p) {
+        return p.equals("1") ? url : (url + "?p=" + p);
+    }
+
     public static String formatParamWithPercentSpace(String value) {
         try {
             return URLEncoder.encode(value, StandardCharsets.UTF_8.name()).replace("+", "%20");


### PR DESCRIPTION
This commit refactors the Bilibili URL construction by introducing a new `createUrlWithPage` function.

This function centralizes the logic for adding the `p` query parameter to Bilibili URLs, and only adds it when the page number is not "1".