### PR TITLE
fix: set JDK 11 for JitPack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Hello !

JitPack has been failing to build v4.7+ because it defaults to Java 8, but the extractor source uses \`Set.of()\`, \`List.of()\` and \`Map.of()\` which are Java 9+ APIs.

Here's what the build log actually says:

\`\`\`
error: cannot find symbol
Set.of("google.", "m.google.", "www.google.")
symbol: method of(java.lang.String, ...)
location: interface java.util.Set

(9 errors total, all in YoutubeParsingHelper.java and YoutubeStreamLinkHandlerFactory.java)
\`\`\`

Full log: https://jitpack.io/com/github/InfinityLoop1308/PipePipeExtractor/af78695668185ad6248ee4be7cb202538d9adb2a/build.log

Adding a `jitpack.yml` with `jdk: openjdk11` tells JitPack to use Java 11 instead. No source changes, `sourceCompatibility` stays at 1.8.

Have a great day !