### PR TITLE
feat(youtube): support podcasts tab and recommended podcasts kiosk

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ChannelTabs.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ChannelTabs.java
@@ -7,6 +7,7 @@ public final class ChannelTabs {
     public static final String LIVESTREAMS = "livestreams";
     public static final String CHANNELS = "channels";
     public static final String PLAYLISTS = "playlists";
+    public static final String PODCASTS = "podcasts";
     public static final String ALBUMS = "albums";
 
     private ChannelTabs() {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelExtractor.java
@@ -674,8 +674,7 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                         .getObject("commandMetadata").getObject("webCommandMetadata")
                         .getString("url");
                 if (tabUrl != null) {
-                    final String[] urlParts = tabUrl.split("/");
-                    final String urlSuffix = urlParts[urlParts.length - 1];
+                    final String urlSuffix = normalizeTabSuffix(tabUrl);
 
                     switch (urlSuffix) {
                         case "videos":
@@ -684,6 +683,9 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
                             break;
                         case "playlists":
                             addTab.accept(ChannelTabs.PLAYLISTS);
+                            break;
+                        case "podcasts":
+                            addTab.accept(ChannelTabs.PODCASTS);
                             break;
                         case "streams":
                             addTab.accept(ChannelTabs.LIVESTREAMS);
@@ -721,6 +723,31 @@ public class YoutubeChannelExtractor extends ChannelExtractor {
 
         this.videoTab = foundVideoTab;
         return foundVideoTab;
+    }
+
+    @Nonnull
+    private static String normalizeTabSuffix(@Nonnull final String tabUrl) {
+        String normalized = tabUrl;
+        final int queryIndex = normalized.indexOf('?');
+        if (queryIndex >= 0) {
+            normalized = normalized.substring(0, queryIndex);
+        }
+
+        final int fragmentIndex = normalized.indexOf('#');
+        if (fragmentIndex >= 0) {
+            normalized = normalized.substring(0, fragmentIndex);
+        }
+
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+
+        final int slashIndex = normalized.lastIndexOf('/');
+        if (slashIndex < 0 || slashIndex == normalized.length() - 1) {
+            return normalized;
+        }
+
+        return normalized.substring(slashIndex + 1);
     }
 
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -69,6 +69,8 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                 return "EghyZWxlYXNlc_IGBQoDsgEA";
             case ChannelTabs.PLAYLISTS:
                 return "EglwbGF5bGlzdHPyBgQKAkIA";
+            case ChannelTabs.PODCASTS:
+                return "Eghwb2RjYXN0c_IGBQoDugEA";
             default:
                 throw new ParsingException("Unsupported channel tab: " + name);
         }
@@ -197,9 +199,10 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         JsonObject foundTab = null;
         for (final Object tab : tabs) {
             if (((JsonObject) tab).has("tabRenderer")) {
-                if (((JsonObject) tab).getObject("tabRenderer").getObject("endpoint")
+                final String tabUrl = ((JsonObject) tab).getObject("tabRenderer").getObject("endpoint")
                         .getObject("commandMetadata").getObject("webCommandMetadata")
-                        .getString("url").endsWith(urlSuffix)) {
+                        .getString("url");
+                if (tabUrl != null && normalizeTabUrl(tabUrl).endsWith(urlSuffix)) {
                     foundTab = ((JsonObject) tab).getObject("tabRenderer");
                     break;
                 }
@@ -309,6 +312,11 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                         return channelIds.get(0);
                     }
                 });
+            } else if (richItem.has("lockupViewModel")) {
+                commitLockupItemIfSupported(collector,
+                        richItem.getObject("lockupViewModel"), channelIds);
+            } else {
+                return collectItem(collector, richItem, channelIds);
             }
         } else if (item.has("gridPlaylistRenderer")) {
             collector.commit(new YoutubePlaylistInfoItemExtractor(
@@ -318,6 +326,12 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                     return channelIds.get(0);
                 }
             });
+        } else if (item.has("playlistRenderer")) {
+            collector.commit(new YoutubeMixOrPlaylistInfoItemExtractor(
+                    item.getObject("playlistRenderer")));
+        } else if (item.has("radioRenderer")) {
+            collector.commit(new YoutubeMixOrPlaylistInfoItemExtractor(
+                    item.getObject("radioRenderer")));
         } else if (item.has("gridChannelRenderer")) {
             collector.commit(new YoutubeChannelInfoItemExtractor(
                     item.getObject("gridChannelRenderer")));
@@ -336,21 +350,71 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         } else if (item.has("continuationItemRenderer")) {
             return item.getObject("continuationItemRenderer");
         } else if (item.has("lockupViewModel")) {
-            final JsonObject lockupViewModel = item.getObject("lockupViewModel");
-            final String contentType = lockupViewModel.getString("contentType");
-            if ("LOCKUP_CONTENT_TYPE_PLAYLIST".equals(contentType)
-                    || "LOCKUP_CONTENT_TYPE_PODCAST".equals(contentType)) {
-                String channelName;
-                try {
-                     channelName = getChannelName();
-                } catch (Exception e) {
-                    channelName = channelIds.get(0);
-                }
-                commitPlaylistLockup(collector, lockupViewModel,
-                        channelName, null);
-            }
+            commitLockupItemIfSupported(collector,
+                    item.getObject("lockupViewModel"), channelIds);
         }
         return null;
+    }
+
+    private void commitLockupItemIfSupported(@Nonnull final MultiInfoItemsCollector collector,
+                                             @Nonnull final JsonObject lockupViewModel,
+                                             @Nonnull final List<String> channelIds) {
+        final String contentType = lockupViewModel.getString("contentType");
+        if ("LOCKUP_CONTENT_TYPE_PLAYLIST".equals(contentType)
+                || "LOCKUP_CONTENT_TYPE_PODCAST".equals(contentType)) {
+            String channelName;
+            try {
+                channelName = getChannelName();
+            } catch (final Exception e) {
+                channelName = channelIds.get(0);
+            }
+            commitPlaylistLockup(collector, lockupViewModel, channelName, null);
+            return;
+        }
+
+        if ("LOCKUP_CONTENT_TYPE_VIDEO".equals(contentType)
+                || "LOCKUP_CONTENT_TYPE_EPISODE".equals(contentType)) {
+            collector.commit(new YoutubeLockupStreamInfoItemExtractor(lockupViewModel,
+                    getTimeAgoParser()) {
+                @Override
+                public String getUploaderName() throws ParsingException {
+                    try {
+                        return super.getUploaderName();
+                    } catch (final ParsingException e) {
+                        return channelIds.get(0);
+                    }
+                }
+
+                @Override
+                public String getUploaderUrl() throws ParsingException {
+                    try {
+                        return super.getUploaderUrl();
+                    } catch (final ParsingException e) {
+                        return channelIds.get(1);
+                    }
+                }
+            });
+        }
+    }
+
+    @Nonnull
+    private static String normalizeTabUrl(@Nonnull final String tabUrl) {
+        String normalized = tabUrl;
+        final int queryIndex = normalized.indexOf('?');
+        if (queryIndex >= 0) {
+            normalized = normalized.substring(0, queryIndex);
+        }
+
+        final int fragmentIndex = normalized.indexOf('#');
+        if (fragmentIndex >= 0) {
+            normalized = normalized.substring(0, fragmentIndex);
+        }
+
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+
+        return normalized;
     }
 
     @Nullable

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelTabLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelTabLinkHandlerFactory.java
@@ -28,6 +28,8 @@ public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFa
                 return "/videos";
             case ChannelTabs.PLAYLISTS:
                 return "/playlists";
+            case ChannelTabs.PODCASTS:
+                return "/podcasts";
             case ChannelTabs.LIVESTREAMS:
                 return "/streams";
             case ChannelTabs.SHORTS:


### PR DESCRIPTION
Refs https://github.com/InfinityLoop1308/PipePipe/issues/577

## Commits
- https://github.com/Priveetee/PipePipeExtractor/commit/c9d1f446
- https://github.com/Priveetee/PipePipeExtractor/commit/6ac89c67
- https://github.com/Priveetee/PipePipeExtractor/commit/9f69bb2b
- https://github.com/Priveetee/PipePipeExtractor/commit/5de75b4c (This is for me not included in this PR)

## Summary
- Add YouTube channel `podcasts` tab extraction support (`/podcasts` mapping + URL normalization for query/fragment/trailing slash variants).
- Add lockup parsing paths used by podcast payloads (`lockupViewModel` for podcast/video content types), including nested rich-item shapes.
- Add `Recommended Podcasts` kiosk support (`/podcasts`, `/podcasts/videos`) and parse feed via `browseId=FEpodcasts_destination` with params `qgcCCAM=`.
- Cap podcast recommendation extraction to 40 items for smoother client scrolling.

## Why
- #577 requires podcast tab support on channel pages and reliable extraction for payload variants that currently lead to empty/incomplete results.
- Client podcast UX also needs a podcast recommendations source instead of generic related items in podcast context.

## Validation
- Build validation:
  - `JAVA_HOME=/usr/lib/jvm/java-11-openjdk ./gradlew :extractor:compileJava -x checkstyleMain` ✅

## Notes
- Commits are intentionally split and each stays under 290 insertions.
- Branch was synced with upstream `main` to resolve conflicts (`Merge origin/main into main`).