### PR TITLE
Validate likes string before parsing to Integer

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -415,7 +415,13 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 return 0;
             }
 
-            return Integer.parseInt(Utils.removeNonDigitCharacters(likesString));
+            final String digitsOnly = Utils.removeNonDigitCharacters(likesString);
+
+            if (digitsOnly == null || digitsOnly.isEmpty()) {
+                throw new ParsingException("Could not extract digits from \"" + likesString + "\"");
+            }
+
+            return Integer.parseInt(digitsOnly);
         } catch (final NumberFormatException nfe) {
             throw new ParsingException("Could not parse \"" + likesString + "\" as an Integer",
                     nfe);


### PR DESCRIPTION
## Description
Add validation to the likes string parser to handle edge cases where no digits are found in the input.

The parser now checks if the processed string is null or empty before attempting to parse it with `Integer.parseInt()`. If validation fails, a descriptive ParsingException is thrown instead of allowing a NumberFormatException to propagate.

This provides clearer error messages and prevents unexpected exceptions during parsing.

## Changes
- Extract the result of `Utils.removeNonDigitCharacters()` into a variable
- Validate that the result is not null and not empty
- Throw a descriptive ParsingException if validation fails
- Parse the validated string with `Integer.parseInt()`

## Before
```java
return Integer.parseInt(Utils.removeNonDigitCharacters(likesString));
```

## After
```java
final String digits = Utils.removeNonDigitCharacters(likesString);
if (digits == null || digits.isEmpty()) {
    throw new ParsingException("Could not parse \"" + likesString + "\": no digits found");
}
return Integer.parseInt(digits);
```

## Benefits
- Clear error messages that help users identify parsing issues
- Improved code readability with extracted variable