### PR TITLE
fix(youtube): parse upload dates from lockup metadata

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeLockupStreamInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeLockupStreamInfoItemExtractor.java
@@ -425,15 +425,27 @@ public class YoutubeLockupStreamInfoItemExtractor implements StreamInfoItemExtra
                 .getObject("contentMetadataViewModel")
                 .getArray("metadataRows");
 
-        if (metadataRows.size() > 1) {
-            final JsonArray metadataParts = metadataRows.getObject(1).getArray("metadataParts");
-            if (metadataParts.size() > 1) {
-                final String uploadText = metadataParts.getObject(1)
+        for (int rowIndex = 0; rowIndex < metadataRows.size(); rowIndex++) {
+            final JsonArray metadataParts = metadataRows.getObject(rowIndex).getArray("metadataParts");
+            for (int partIndex = 0; partIndex < metadataParts.size(); partIndex++) {
+                final String uploadText = metadataParts.getObject(partIndex)
                         .getObject("text")
                         .getString("content");
+                if (isNullOrEmpty(uploadText)) {
+                    continue;
+                }
 
-                if (!isNullOrEmpty(uploadText)) {
+                if (timeAgoParser == null) {
+                    if (partIndex == 1) {
+                        return uploadText;
+                    }
+                    continue;
+                }
+
+                try {
+                    timeAgoParser.parse(uploadText);
                     return uploadText;
+                } catch (final ParsingException ignored) {
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR fixes empty subscription feed refresh results for YouTube channel tabs that are returned as `lockupViewModel` items.

The patch is small because the root cause is localized: `YoutubeLockupStreamInfoItemExtractor` was able to extract the video items, but failed to extract their upload dates from the current YouTube metadata layout. The client then discarded these items from the feed because normal video items without an upload date are not inserted.

## Related reports

- Refs [InfinityLoop1308/PipePipe#2309](https://github.com/InfinityLoop1308/PipePipe/issues/2309)
- Related upstream symptoms:
  - [TeamNewPipe/NewPipe#13512](https://github.com/TeamNewPipe/NewPipe/issues/13512)
  - [FreeTubeApp/FreeTube#9163](https://github.com/FreeTubeApp/FreeTube/issues/9163)

## Problem

Refreshing subscriptions could produce an empty feed even though the extractor still returned channel tab videos.

Observed flow:

- YouTube channel tabs currently return videos as `richItemRenderer.content.lockupViewModel`.
- `YoutubeChannelTabExtractor` already supports committing these `lockupViewModel` video items.
- However, `YoutubeLockupStreamInfoItemExtractor#getTextualUploadDate()` expected the upload date at a fixed metadata position.
- In the current YouTube response, the date can appear in another metadata part.
- As a result, extracted `StreamInfoItem`s had `textualUploadDate=null` and `uploadDate=null`.
- PipePipeClient then filtered these items out of the feed because they are normal video streams without an upload date.

This means the client was not failing to fetch videos. It received video items, but they were incomplete from the extractor side.

## Investigation highlights

Direct extractor probe on `https://www.youtube.com/@MrBeast` before this patch:

```text
tab=videos items=30 errors=0
item0 textualUploadDate=null uploadDate=null
item1 textualUploadDate=null uploadDate=null
item2 textualUploadDate=null uploadDate=null
```

The raw YouTube metadata for the first video contained the upload date, but not at the previously assumed position:

```text
row=0 part=0 content=58M ukubukwa
row=0 part=1 content=ezinsukwini ezingu-4 ezedlule.
```

So the date was present in the YouTube response, but the lockup extractor did not find it.

## Code change

File:

- `extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeLockupStreamInfoItemExtractor.java`

Change:

- Do not assume the upload date is always at `metadataRows[1].metadataParts[1]`.
- Iterate through lockup metadata parts.
- Return the first metadata text that can be parsed by `timeAgoParser`.
- Keep the existing fallback behavior when no parser is available.

This avoids treating view-count text as an upload date: for example, `58M ukubukwa` is tested and ignored, while `ezinsukwini ezingu-4 ezedlule.` is accepted because it parses as a time-ago date.

## Validation

### Extractor validation

After this patch, the same direct extractor probe returns upload dates for the videos tab:

```text
tab=videos items=30 errors=0
item0 textualUploadDate=ezinsukwini ezingu-4 ezedlule. uploadDate=<non-null>
item1 textualUploadDate=amaviki angu-2 edlule uploadDate=<non-null>
item2 textualUploadDate=1 inyanga edlule uploadDate=<non-null>
```

### Client feed A/B validation

Using a debug PipePipeClient build with local PipePipeExtractor substitution and a single subscription:

```text
https://www.youtube.com/@MrBeast
```

Before this patch:

```text
subscriptions=1
streams=0
feed=0
feed_last_updated=1
```

After this patch:

```text
subscriptions=1
streams=9
feed=9
feed_last_updated=1
```

Sample rows stored after refresh:

```text
Survive 30 Days On An Island With Your Ex, Win $250,000 | ezinsukwini ezingu-4 ezedlule. | 1779001200000
I Stranded 100 People In The Wilderness For $250,000 | amaviki angu-2 edlule | 1778137200000
Last To Leave Grocery Store, Wins $250,000 | 1 inyanga edlule | 1776754800000
```

## Build verification

- `./gradlew :extractor:compileJava -x checkstyleMain` OK
- `./gradlew :app:assembleDebug` with local extractor substitution OK
- Installed patched debug APK on `emulator-5554` and verified subscription feed refresh OK
- `git diff --check` OK

## Notes

- No PipePipeClient behavior change is required.
- The client-side feed filtering is left unchanged.
- Shorts still may not provide upload dates in the tested payload, but this PR fixes the normal Videos tab path responsible for the empty subscription feed symptom.
