### PR TITLE
feat(youtube): support channel tab sorting

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -101,7 +101,8 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
     public String getUrl() throws ParsingException {
         try {
             return YoutubeChannelTabLinkHandlerFactory.getInstance().getUrl("channel/" + getId(),
-                    Collections.singletonList(new FilterItem(-1, getTab())), null);
+                    Collections.singletonList(new FilterItem(-1, getTab())),
+                    getLinkHandler().getSortFilter());
         } catch (final ParsingException e) {
             return super.getUrl();
         }
@@ -127,23 +128,14 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         Page nextPage = null;
 
         if (getTabData() != null) {
-            final JsonObject tabContent = tabData.getObject("content");
-            JsonArray items = tabContent
-                    .getObject("sectionListRenderer")
-                    .getArray("contents").getObject(0).getObject("itemSectionRenderer")
-                    .getArray("contents").getObject(0).getObject("gridRenderer").getArray("items");
-
-            if (items.isEmpty()) {
-                items = tabContent.getObject("richGridRenderer").getArray("contents");
-
-                if (items.isEmpty()) {
-                    items = tabContent.getObject("sectionListRenderer").getArray("contents");
-                }
-            }
+            final JsonArray items = getSelectedSortFilterIndex() > 0
+                    ? getSortedItemsFrom(tabData)
+                    : getInitialItemsFrom(tabData);
 
             final List<String> channelIds = new ArrayList<>();
             channelIds.add(getChannelName());
-            channelIds.add(YoutubeChannelLinkHandlerFactory.getInstance().getUrl("channel/" + getId()));
+            channelIds.add(YoutubeChannelLinkHandlerFactory.getInstance()
+                    .getUrl("channel/" + getId()));
             final JsonObject continuation = collectItemsFrom(collector, items, channelIds);
 
             nextPage = getNextPageFrom(continuation, channelIds);
@@ -152,6 +144,94 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
             collector.applyBlocking(ServiceList.YouTube.getFilterConfig());
         }
         return new InfoItemsPage<>(collector, nextPage);
+    }
+
+    @Nonnull
+    private JsonArray getInitialItemsFrom(@Nonnull final JsonObject currentTabData) {
+        final JsonObject tabContent = currentTabData.getObject("content");
+        JsonArray items = tabContent
+                .getObject("sectionListRenderer")
+                .getArray("contents").getObject(0).getObject("itemSectionRenderer")
+                .getArray("contents").getObject(0).getObject("gridRenderer").getArray("items");
+
+        if (items.isEmpty()) {
+            items = tabContent.getObject("richGridRenderer").getArray("contents");
+
+            if (items.isEmpty()) {
+                items = tabContent.getObject("sectionListRenderer").getArray("contents");
+            }
+        }
+
+        return items;
+    }
+
+    @Nonnull
+    private JsonArray getSortedItemsFrom(@Nonnull final JsonObject currentTabData)
+            throws IOException, ExtractionException {
+        final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(getExtractorLocalization(),
+                        getExtractorContentCountry())
+                        .value("continuation", getSortContinuationToken(currentTabData))
+                        .done())
+                .getBytes(StandardCharsets.UTF_8);
+
+        final Map<String, List<String>> headers = new HashMap<>();
+        addYoutubeHeaders(headers);
+        headers.put("Content-Type", Collections.singletonList("application/json"));
+
+        final Response response = getDownloader().post(YOUTUBEI_V1_URL + "browse?"
+                        + DISABLE_PRETTY_PRINT_PARAMETER, headers, body,
+                getExtractorLocalization());
+
+        final JsonObject ajaxJson = JsonUtils.toJsonObject(getValidJsonResponseBody(response));
+        return getContinuationItemsFrom(ajaxJson, "reloadContinuationItemsCommand");
+    }
+
+    @Nonnull
+    private String getSortContinuationToken(@Nonnull final JsonObject currentTabData)
+            throws ParsingException {
+        final int sortIndex = getSelectedSortFilterIndex();
+        final JsonArray chips = currentTabData.getObject("content")
+                .getObject("richGridRenderer")
+                .getObject("header")
+                .getObject("chipBarViewModel")
+                .getArray("chips");
+
+        if (chips.size() <= sortIndex) {
+            throw new ParsingException("YouTube channel tab sort filter is not available");
+        }
+
+        final String token = chips.getObject(sortIndex)
+                .getObject("chipViewModel")
+                .getObject("tapCommand")
+                .getObject("innertubeCommand")
+                .getObject("continuationCommand")
+                .getString("token");
+
+        if (isNullOrEmpty(token)) {
+            throw new ParsingException("Could not get YouTube channel tab sort continuation");
+        }
+
+        return token;
+    }
+
+    private int getSelectedSortFilterIndex() throws ParsingException {
+        final List<FilterItem> sortFilter = getLinkHandler().getSortFilter();
+        if (sortFilter == null || sortFilter.isEmpty()) {
+            return 0;
+        }
+
+        final String sortFilterName = sortFilter.get(0).getName();
+        switch (sortFilterName) {
+            case YoutubeChannelTabLinkHandlerFactory.SORT_LATEST:
+                return 0;
+            case YoutubeChannelTabLinkHandlerFactory.SORT_POPULAR:
+                return 1;
+            case YoutubeChannelTabLinkHandlerFactory.SORT_OLDEST:
+                return 2;
+            default:
+                throw new ParsingException("Unsupported YouTube channel tab sort filter: "
+                        + sortFilterName);
+        }
     }
 
     @Override
@@ -166,23 +246,61 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         final MultiInfoItemsCollector collector = new MultiInfoItemsCollector(getServiceId());
         final Map<String, List<String>> headers = new HashMap<>();
         addYoutubeHeaders(headers);
+        headers.put("Content-Type", Collections.singletonList("application/json"));
 
         final Response response = getDownloader().post(page.getUrl(), headers, page.getBody(),
                 getExtractorLocalization());
 
         final JsonObject ajaxJson = JsonUtils.toJsonObject(getValidJsonResponseBody(response));
 
-        final JsonObject sectionListContinuation = ajaxJson.getArray("onResponseReceivedActions")
-                .getObject(0)
-                .getObject("appendContinuationItemsAction");
-
-        final JsonObject continuation = collectItemsFrom(collector, sectionListContinuation
-                .getArray("continuationItems"), channelIds);
+        final JsonObject continuation = collectItemsFrom(collector,
+                getContinuationItemsFrom(ajaxJson, "appendContinuationItemsAction"), channelIds);
         if (ServiceList.YouTube.getFilterTypes().contains("channels")) {
             collector.applyBlocking(ServiceList.YouTube.getFilterConfig());
         }
         return new InfoItemsPage<>(collector,
                 getNextPageFrom(continuation, channelIds));
+    }
+
+    @Nonnull
+    private JsonArray getContinuationItemsFrom(@Nonnull final JsonObject ajaxJson,
+                                               @Nonnull final String commandName)
+            throws ParsingException {
+        final JsonArray items = new JsonArray();
+        addContinuationItemsFrom(ajaxJson, commandName, items);
+
+        if (items.isEmpty() && "appendContinuationItemsAction".equals(commandName)) {
+            addContinuationItemsFrom(ajaxJson, "reloadContinuationItemsCommand", items);
+        } else if (items.isEmpty() && "reloadContinuationItemsCommand".equals(commandName)) {
+            addContinuationItemsFrom(ajaxJson, "appendContinuationItemsAction", items);
+        }
+
+        if (items.isEmpty()) {
+            throw new ParsingException("Could not get YouTube channel tab continuation items");
+        }
+
+        return items;
+    }
+
+    private void addContinuationItemsFrom(@Nonnull final Object object,
+                                          @Nonnull final String commandName,
+                                          @Nonnull final JsonArray targetItems) {
+        if (object instanceof JsonObject) {
+            final JsonObject jsonObject = (JsonObject) object;
+            final JsonArray continuationItems = jsonObject.getObject(commandName)
+                    .getArray("continuationItems");
+            for (final Object continuationItem : continuationItems) {
+                targetItems.add(continuationItem);
+            }
+
+            for (final Object value : jsonObject.values()) {
+                addContinuationItemsFrom(value, commandName, targetItems);
+            }
+        } else if (object instanceof JsonArray) {
+            for (final Object value : (JsonArray) object) {
+                addContinuationItemsFrom(value, commandName, targetItems);
+            }
+        }
     }
 
     @Nullable

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelTabLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelTabLinkHandlerFactory.java
@@ -3,19 +3,41 @@ package org.schabi.newpipe.extractor.services.youtube.linkHandler;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ChannelTabs;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
+import org.schabi.newpipe.extractor.search.filter.Filter;
+import org.schabi.newpipe.extractor.search.filter.FilterGroup;
 import org.schabi.newpipe.extractor.search.filter.FilterItem;
-import org.schabi.newpipe.extractor.services.youtube.search.filter.YoutubeFilters;
 
 import java.util.List;
 
 import javax.annotation.Nonnull;
 
 public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFactory {
+    public static final String SORT_LATEST = "latest";
+    public static final String SORT_POPULAR = "popular";
+    public static final String SORT_OLDEST = "oldest";
+
     private static final YoutubeChannelTabLinkHandlerFactory INSTANCE =
             new YoutubeChannelTabLinkHandlerFactory();
-    private final YoutubeFilters searchFilters = new YoutubeFilters();
+    private final FilterGroup.Builder filterBuilder;
+    private final Filter availableSortFilter;
 
     private YoutubeChannelTabLinkHandlerFactory() {
+        filterBuilder = new FilterGroup.Builder();
+
+        final int latestFilterId = filterBuilder.addSortItem(
+                new FilterItem(Filter.ITEM_IDENTIFIER_UNKNOWN, SORT_LATEST));
+        final int popularFilterId = filterBuilder.addSortItem(
+                new FilterItem(Filter.ITEM_IDENTIFIER_UNKNOWN, SORT_POPULAR));
+        final int oldestFilterId = filterBuilder.addSortItem(
+                new FilterItem(Filter.ITEM_IDENTIFIER_UNKNOWN, SORT_OLDEST));
+
+        availableSortFilter = new Filter.Builder(new FilterGroup[]{
+                filterBuilder.createSortGroup("sortby", true, new FilterItem[]{
+                        filterBuilder.getFilterForId(latestFilterId),
+                        filterBuilder.getFilterForId(popularFilterId),
+                        filterBuilder.getFilterForId(oldestFilterId),
+                })
+        }).build();
     }
 
     public static YoutubeChannelTabLinkHandlerFactory getInstance() {
@@ -41,10 +63,46 @@ public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFa
     }
 
     @Override
-    public String getUrl(final String id,@Nonnull final List<FilterItem> selectedContentFilter,
+    public String getUrl(final String id,
+                         @Nonnull final List<FilterItem> selectedContentFilter,
                          final List<FilterItem> selectedSortFilter)
             throws ParsingException {
-        return "https://www.youtube.com/" + id + getUrlSuffix(selectedContentFilter.get(0).getName());
+        return "https://www.youtube.com/" + id
+                + getUrlSuffix(selectedContentFilter.get(0).getName())
+                + getSortUrlQuery(selectedSortFilter);
+    }
+
+    private static String getSortUrlQuery(final List<FilterItem> selectedSortFilter)
+            throws ParsingException {
+        if (selectedSortFilter == null || selectedSortFilter.isEmpty()) {
+            return "";
+        }
+
+        final String selectedSortFilterName = selectedSortFilter.get(0).getName();
+        switch (selectedSortFilterName) {
+            case SORT_LATEST:
+            case SORT_POPULAR:
+            case SORT_OLDEST:
+                return "?sort=" + selectedSortFilterName;
+            default:
+                throw new ParsingException("Unsupported YouTube channel tab sort filter: "
+                        + selectedSortFilterName);
+        }
+    }
+
+    @Override
+    public Filter getAvailableSortFilter() {
+        return availableSortFilter;
+    }
+
+    @Override
+    public Filter getContentFilterSortFilterVariant(final int contentFilterId) {
+        return availableSortFilter;
+    }
+
+    @Override
+    public FilterItem getFilterItem(final int filterId) {
+        return filterBuilder.getFilterForId(filterId);
     }
 
     @Override


### PR DESCRIPTION
Refs https://github.com/InfinityLoop1308/PipePipe/issues/1279

## Commits
- https://github.com/Priveetee/PipePipeExtractor/commit/14beca97

## Summary
- Add YouTube channel tab sort filters for `latest`, `popular` and `oldest`.
- Load sorted channel tabs through YouTube chip continuation commands.
- Keep separate cache URLs for each selected sort.
- Support sorted channel tab pagination for continuation payload variants.

## Why
- https://github.com/InfinityLoop1308/PipePipe/issues/1279 asks for sorting YouTube channel videos by latest, popular and oldest.
- YouTube exposes this through channel tab chips, not stable legacy URL params.

## Validation
- `./gradlew :extractor:compileJava -x checkstyleMain`
- Tested latest, popular and oldest on YouTube channel videos.
- Tested pagination for sorted channel tabs.
- Tested shorts popular pagination.

## Notes
- `checkstyleMain` is excluded because it still fails on existing generated/repo-wide issues unrelated to this change.
