### PR TITLE
fix(youtube): fetch Safari HLS fallback anonymously

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1334,6 +1334,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             CancellableCall safariCall = null;
 
             if (StringUtils.isBlank(ServiceList.YouTube.getTokens())) {
+                try {
+                    safariCall = fetchSafariJsonPlayer(contentCountry, localization, videoId);
+                } catch (final Exception e) {
+                    errors.add(e);
+                }
                 androidCall = fetchAndroidMobileJsonPlayer(contentCountry, localization, videoId);
             } else {
                 safariCall = fetchSafariJsonPlayer(contentCountry, localization, videoId);


### PR DESCRIPTION
Refs [PipePipe#2330: [YouTube] Content Not Yet Suppoted (SABR) after 5.1.0](https://github.com/InfinityLoop1308/PipePipe/issues/2330)

Related:
- [PipePipeExtractor#62: feat(youtube): support channel tab sorting](https://github.com/InfinityLoop1308/PipePipeExtractor/pull/62#issuecomment-4528105362)
- [PipePipe#2310: [Bug] Content not yet supported error](https://github.com/InfinityLoop1308/PipePipe/issues/2310)
- [NewPipe#12248: [YouTube] Coordinating efforts on SABR implementation](https://github.com/TeamNewPipe/NewPipe/issues/12248)

## Summary
- Also request the Safari player response when YouTube is used anonymously.
- Keep Android as the required anonymous player response.
- Use Safari only as an extra fallback source for `hlsManifestUrl`.
- Keep the logged-in path unchanged.

## Why
YouTube is enforcing SABR more aggressively for anonymous users.

The current temporary workaround retries SABR-only responses, but for users where the Android response stays SABR-only, stream extraction still fails before the app can use any fallback.

For some affected videos, the Safari player response still exposes an HLS manifest. Fetching it anonymously gives the existing HLS fallback path a chance to work instead of failing early with:

`YouTube returned SABR-only streaming data without usable stream URLs`

This is not a full SABR implementation, just another small workaround while SABR is still unresolved.

## Validation
- `./gradlew :extractor:compileJava -x checkstyleMain`
- Built a debug client APK with this extractor through the included build.
- Installed and tested on Android device.
- Tested anonymous YouTube stream loading with:
  - `https://www.youtube.com/watch?v=vIr-y_djvmk`
  - `https://www.youtube.com/watch?v=sJtBOUR4L30`
- Confirmed `getStreamInfo` succeeds and `hlsUrl=true` is available.
- Confirmed the previous SABR-only error notification no longer appears in the tested cases.

## Notes
This is a workaround, not real SABR support.

If YouTube removes this fallback too, we will still need proper SABR support in extractor/player. But for now this avoids failing early when an HLS fallback is still available.
