### PR TITLE
feat(youtube): support channel search extraction

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ChannelTabs.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/linkhandler/ChannelTabs.java
@@ -9,6 +9,7 @@ public final class ChannelTabs {
     public static final String PLAYLISTS = "playlists";
     public static final String PODCASTS = "podcasts";
     public static final String ALBUMS = "albums";
+    public static final String SEARCH = "search";
 
     private ChannelTabs() {
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -2186,20 +2186,33 @@ YoutubeParsingHelper {
     }
 
     public static ChannelResponseData getChannelResponse(final String channelId,
-                                                         final String params,
-                                                         final Localization loc,
-                                                         final ContentCountry country)
+                                                          final String params,
+                                                          final Localization loc,
+                                                          final ContentCountry country)
+            throws ExtractionException, IOException {
+        return getChannelResponse(channelId, params, null, loc, country);
+    }
+
+    public static ChannelResponseData getChannelResponse(final String channelId,
+                                                          final String params,
+                                                          @Nullable final String query,
+                                                          final Localization loc,
+                                                          final ContentCountry country)
             throws ExtractionException, IOException {
         String id = channelId;
         JsonObject ajaxJson = null;
 
         int level = 0;
         while (level < 3) {
-            final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(
+            final JsonBuilder<JsonObject> bodyBuilder = prepareDesktopJsonBuilder(
                             loc, country)
                             .value("browseId", id)
-                            .value("params", params) // Equal to videos
-                            .done())
+                            .value("params", params); // Equal to videos
+            if (!isNullOrEmpty(query)) {
+                bodyBuilder.value("query", query);
+            }
+
+            final byte[] body = JsonWriter.string(bodyBuilder.done())
                     .getBytes(UTF_8);
 
             final JsonObject jsonResponse = getJsonPostResponse("browse", body, loc);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -72,6 +72,8 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                 return "EglwbGF5bGlzdHPyBgQKAkIA";
             case ChannelTabs.PODCASTS:
                 return "Eghwb2RjYXN0c_IGBQoDugEA";
+            case ChannelTabs.SEARCH:
+                return "EgZzZWFyY2jyBgQKAloA";
             default:
                 throw new ParsingException("Unsupported channel tab: " + name);
         }
@@ -86,7 +88,7 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         final String params = getChannelTabsParameters();
 
         final ChannelResponseData data = getChannelResponse(channelIdFromId,
-                params, getExtractorLocalization(), getExtractorContentCountry());
+                params, getSearchQuery(), getExtractorLocalization(), getExtractorContentCountry());
 
         jsonResponse = data.responseJson;
         channelHeader = YoutubeChannelHelper.getChannelHeader(jsonResponse);
@@ -100,9 +102,12 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
     @Override
     public String getUrl() throws ParsingException {
         try {
-            return YoutubeChannelTabLinkHandlerFactory.getInstance().getUrl("channel/" + getId(),
+            final String url = YoutubeChannelTabLinkHandlerFactory.getInstance().getUrl(
+                    "channel/" + getId(),
                     Collections.singletonList(new FilterItem(-1, getTab())),
                     getLinkHandler().getSortFilter());
+            return YoutubeChannelTabLinkHandlerFactory.appendSearchQueryIfNeeded(
+                    url, getSearchQuery());
         } catch (final ParsingException e) {
             return super.getUrl();
         }
@@ -317,14 +322,17 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
 
         JsonObject foundTab = null;
         for (final Object tab : tabs) {
-            if (((JsonObject) tab).has("tabRenderer")) {
-                final String tabUrl = ((JsonObject) tab).getObject("tabRenderer").getObject("endpoint")
-                        .getObject("commandMetadata").getObject("webCommandMetadata")
-                        .getString("url");
-                if (tabUrl != null && normalizeTabUrl(tabUrl).endsWith(urlSuffix)) {
-                    foundTab = ((JsonObject) tab).getObject("tabRenderer");
-                    break;
-                }
+            final JsonObject tabRenderer = getTabRenderer((JsonObject) tab);
+            if (tabRenderer == null) {
+                continue;
+            }
+
+            final String tabUrl = tabRenderer.getObject("endpoint")
+                    .getObject("commandMetadata").getObject("webCommandMetadata")
+                    .getString("url");
+            if (tabUrl != null && normalizeTabUrl(tabUrl).endsWith(urlSuffix)) {
+                foundTab = tabRenderer;
+                break;
             }
         }
 
@@ -414,6 +422,8 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
 
         if (item.has("gridVideoRenderer")) {
             commitVideo.accept(item.getObject("gridVideoRenderer"));
+        } else if (item.has("videoRenderer")) {
+            commitVideo.accept(item.getObject("videoRenderer"));
         } else if (item.has("richItemRenderer")) {
             final JsonObject richItem = item.getObject("richItemRenderer").getObject("content");
 
@@ -454,6 +464,9 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         } else if (item.has("gridChannelRenderer")) {
             collector.commit(new YoutubeChannelInfoItemExtractor(
                     item.getObject("gridChannelRenderer")));
+        } else if (item.has("channelRenderer")) {
+            collector.commit(new YoutubeChannelInfoItemExtractor(
+                    item.getObject("channelRenderer")));
         } else if (item.has("shelfRenderer")) {
             return collectItem(collector, item.getObject("shelfRenderer")
                     .getObject("content"), channelIds);
@@ -471,6 +484,26 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         } else if (item.has("lockupViewModel")) {
             commitLockupItemIfSupported(collector,
                     item.getObject("lockupViewModel"), channelIds);
+        }
+        return null;
+    }
+
+    @Nullable
+    private String getSearchQuery() throws ParsingException {
+        if (!ChannelTabs.SEARCH.equals(getTab())) {
+            return null;
+        }
+
+        return YoutubeChannelTabLinkHandlerFactory.getSearchQueryFromUrl(getOriginalUrl());
+    }
+
+    @Nullable
+    private static JsonObject getTabRenderer(@Nonnull final JsonObject tab) {
+        if (tab.has("tabRenderer")) {
+            return tab.getObject("tabRenderer");
+        }
+        if (tab.has("expandableTabRenderer")) {
+            return tab.getObject("expandableTabRenderer");
         }
         return null;
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelTabLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/linkHandler/YoutubeChannelTabLinkHandlerFactory.java
@@ -2,14 +2,22 @@ package org.schabi.newpipe.extractor.services.youtube.linkHandler;
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.ChannelTabs;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
 import org.schabi.newpipe.extractor.linkhandler.ListLinkHandlerFactory;
 import org.schabi.newpipe.extractor.search.filter.Filter;
 import org.schabi.newpipe.extractor.search.filter.FilterGroup;
 import org.schabi.newpipe.extractor.search.filter.FilterItem;
+import org.schabi.newpipe.extractor.utils.Utils;
 
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+
+import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
 public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFactory {
     public static final String SORT_LATEST = "latest";
@@ -58,6 +66,8 @@ public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFa
                 return "/shorts";
             case ChannelTabs.CHANNELS:
                 return "/channels";
+            case ChannelTabs.SEARCH:
+                return "/search";
         }
         throw new ParsingException("tab " + tab + " not supported");
     }
@@ -91,6 +101,26 @@ public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFa
     }
 
     @Override
+    public ListLinkHandler fromUrl(final String url, final String baseUrl) throws ParsingException {
+        if (url == null) {
+            throw new IllegalArgumentException("url may not be null");
+        }
+        if (!acceptUrl(url)) {
+            throw new ParsingException("URL not accepted: " + url);
+        }
+
+        final String id = getId(url);
+        final String tab = getTabFromUrl(url);
+        final List<FilterItem> contentFilter = Collections.singletonList(
+                new FilterItem(Filter.ITEM_IDENTIFIER_UNKNOWN, tab));
+        String cleanUrl = getUrl(id, contentFilter, null, baseUrl);
+        if (ChannelTabs.SEARCH.equals(tab)) {
+            cleanUrl = appendSearchQueryIfNeeded(cleanUrl, getSearchQueryFromUrl(url));
+        }
+        return new ListLinkHandler(url, cleanUrl, id, contentFilter, null);
+    }
+
+    @Override
     public Filter getAvailableSortFilter() {
         return availableSortFilter;
     }
@@ -120,5 +150,66 @@ public final class YoutubeChannelTabLinkHandlerFactory extends ListLinkHandlerFa
         return true;
     }
 
+    public static String getSearchQueryFromUrl(final String url) throws ParsingException {
+        try {
+            final URL urlObj = Utils.stringToURL(url);
+            final String query = firstNonEmptyQueryValue(urlObj, "query", "search_query", "q");
+            return query == null ? "" : query;
+        } catch (final Exception e) {
+            throw new ParsingException("Could not parse channel search query", e);
+        }
+    }
 
+    public static String appendSearchQueryIfNeeded(final String url,
+                                                   final String query) throws ParsingException {
+        if (isNullOrEmpty(query)) {
+            return url;
+        }
+
+        try {
+            return url + "?query=" + URLEncoder.encode(query, UTF_8).replace("+", "%20");
+        } catch (final Exception e) {
+            throw new ParsingException("Could not encode channel search query", e);
+        }
+    }
+
+    private String getTabFromUrl(final String url) throws ParsingException {
+        try {
+            final URL urlObj = Utils.stringToURL(url);
+            final String[] pathSegments = urlObj.getPath().split("/");
+            for (int i = pathSegments.length - 1; i >= 0; i--) {
+                switch (pathSegments[i]) {
+                    case "videos":
+                        return ChannelTabs.VIDEOS;
+                    case "playlists":
+                        return ChannelTabs.PLAYLISTS;
+                    case "podcasts":
+                        return ChannelTabs.PODCASTS;
+                    case "streams":
+                        return ChannelTabs.LIVESTREAMS;
+                    case "shorts":
+                        return ChannelTabs.SHORTS;
+                    case "channels":
+                        return ChannelTabs.CHANNELS;
+                    case "search":
+                        return ChannelTabs.SEARCH;
+                }
+            }
+        } catch (final Exception e) {
+            throw new ParsingException("Could not parse channel tab URL: " + e.getMessage(), e);
+        }
+
+        return ChannelTabs.VIDEOS;
+    }
+
+    private static String firstNonEmptyQueryValue(final URL url,
+                                                  final String... names) {
+        for (final String name : names) {
+            final String value = Utils.getQueryValue(url, name);
+            if (!isNullOrEmpty(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
This adds the extractor side for YouTube channel search.

It supports URLs like:

`https://www.youtube.com/@somechannel/search?query=test`

and also:

`https://www.youtube.com/channel/UC.../search?query=test`

The extractor now keeps the search query in the clean URL and sends it to YouTube in the channel `browse` request, so different searches from the same channel don't get mixed together.

For the client side, honestly I had 0 inspiration on how to implement it properly for now, so I kept this PR extractor-only instead of adding some random half-baked UI.

So this does not add the full visible feature in the app yet. It only makes the extractor able to load the results once the client has a way to call it.

I also didn't add search as a normal channel tab, because unlike videos/shorts/playlists it needs a query from the user before it can do anything.

Supported query params:

- `query`
- `search_query`
- `q`

Refs [InfinityLoop1308/PipePipe#1350](https://github.com/InfinityLoop1308/PipePipe/issues/1350)

Tested:

- `git diff --check`
- `compileJava`
- `compileTestJava`
- local checks with handle URLs
- local checks with channel ID URLs
- query aliases
- encoded queries with spaces
- empty/no-result searches
- existing videos/shorts/playlists/livestreams tabs
- channel search pagination
