### PR TITLE
fix(youtube): extract playlist videos from lockups

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -272,6 +272,19 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
             collectStreamsFrom(collector, videosArray);
 
             nextPage = getNextPageFrom(videosArray);
+        } else {
+            for (final Object content : contents) {
+                if (!(content instanceof JsonObject)) {
+                    continue;
+                }
+                final JsonArray itemContents = ((JsonObject) content)
+                        .getObject("itemSectionRenderer")
+                        .getArray("contents");
+                collectStreamsFrom(collector, itemContents);
+                if (nextPage == null) {
+                    nextPage = getNextPageFrom(itemContents);
+                }
+            }
         }
 
         // Handle richGridRenderer for Shorts playlists
@@ -416,7 +429,15 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                     return extractor;
                 })
                 .forEachOrdered(collector::commit);
-        
+
+        videos.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .filter(video -> video.has("lockupViewModel"))
+                .map(video -> video.getObject("lockupViewModel"))
+                .forEachOrdered(lockup -> commitLockupStreamIfSupported(
+                        collector, lockup, timeAgoParser, fallbackName, fallbackUrl));
+
         // Handle Shorts in richItemRenderer format (for continuation responses)
         videos.stream()
                 .filter(JsonObject.class::isInstance)
@@ -428,6 +449,46 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
                     collector.commit(new YoutubeShortsInfoItemExtractor(
                             content.getObject("shortsLockupViewModel")));
                 });
+
+        videos.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .filter(video -> video.has("richItemRenderer"))
+                .map(video -> video.getObject("richItemRenderer").getObject("content"))
+                .filter(content -> content.has("lockupViewModel"))
+                .map(content -> content.getObject("lockupViewModel"))
+                .forEachOrdered(lockup -> commitLockupStreamIfSupported(
+                        collector, lockup, timeAgoParser, fallbackName, fallbackUrl));
+    }
+
+    private void commitLockupStreamIfSupported(@Nonnull final StreamInfoItemsCollector collector,
+                                               @Nonnull final JsonObject lockupViewModel,
+                                               @Nonnull final TimeAgoParser timeAgoParser,
+                                               @Nullable final String fallbackName,
+                                               @Nullable final String fallbackUrl) {
+        final String contentType = lockupViewModel.getString("contentType");
+        if (!"LOCKUP_CONTENT_TYPE_VIDEO".equals(contentType)
+                && !"LOCKUP_CONTENT_TYPE_EPISODE".equals(contentType)) {
+            return;
+        }
+        if (isNullOrEmpty(lockupViewModel.getObject("metadata")
+                .getObject("lockupMetadataViewModel")
+                .getObject("title")
+                .getString("content"))) {
+            return;
+        }
+
+        collector.commit(new YoutubeLockupStreamInfoItemExtractor(lockupViewModel, timeAgoParser) {
+            @Override
+            public String getUploaderName() throws ParsingException {
+                return fallbackName == null ? super.getUploaderName() : fallbackName;
+            }
+
+            @Override
+            public String getUploaderUrl() throws ParsingException {
+                return fallbackUrl == null ? super.getUploaderUrl() : fallbackUrl;
+            }
+        });
     }
 
     @Nonnull


### PR DESCRIPTION
Found while working on TypeType public YouTube playlist support:

https://github.com/Priveetee/TypeType/issues/57

Refs:

- https://github.com/InfinityLoop1308/PipePipe/issues/2262

Related:

- https://github.com/InfinityLoop1308/PipePipe/issues/2465
- https://github.com/InfinityLoop1308/PipePipe/issues/2451
- https://github.com/InfinityLoop1308/PipePipe/issues/2460

## Summary

While working on public YouTube playlist support for TypeType, I found that PipePipeExtractor can load playlist metadata but returns no videos for affected YouTube playlists.

This fixes YouTube playlists returning empty `relatedItems` when YouTube serves playlist entries as `lockupViewModel` items instead of the older `playlistVideoListRenderer` / `playlistVideoRenderer` layout.

## Problem

Current playlist extraction can still load the playlist title, thumbnail and stream count, but `relatedItems` is empty.

Observed on a public YouTube playlist:

```text
https://www.youtube.com/playlist?list=PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs

title=Google - Year In Search (unofficial)
count=19
items=0
next=false
errors=0
```

The current response no longer contains the old playlist video renderers:

```text
playlistVideoListRenderer=0
playlistVideoRenderer=0
```

but it does contain the current lockup format:

```text
lockupViewModel=20
```

So the extractor was successfully loading the playlist page, but ignored the current video item layout.

## Changes

- Add a fallback path in `YoutubePlaylistExtractor` when `playlistVideoListRenderer` is absent.
- Collect direct `lockupViewModel` video entries from playlist item sections.
- Collect nested `richItemRenderer.content.lockupViewModel` entries too.
- Reuse `YoutubeLockupStreamInfoItemExtractor` for `LOCKUP_CONTENT_TYPE_VIDEO` and `LOCKUP_CONTENT_TYPE_EPISODE`.
- Keep playlist uploader name/url as fallback values for playlist video items.
- Ignore lockup entries without a title instead of adding tolerated item parsing errors.

## Validation

- `git diff --check`
- `./gradlew :extractor:compileJava`
- `./gradlew :extractor:compileTestJava`
- Local extractor probe against:

```text
https://www.youtube.com/playlist?list=PL590L5WQmH8fJ54F369BLDSqIwcs-TCfs
```

Before:

```text
items=0
errors=0
```

After:

```text
items=14
```

Sample extracted items:

```text
2016 — Year in Search | https://www.youtube.com/watch?v=KIViy7L_lo8
2015 — Year in Search | https://www.youtube.com/watch?v=q7o7R5BgWDY
2014 — Year in Search | https://www.youtube.com/watch?v=DVwHCGAr_OE
```

## Notes

This is intentionally limited to the playlist extractor. Search and channel tabs already have separate lockup handling paths, so this only fixes playlist pages where `PlaylistInfo.getInfo(...)` was returning an empty item list.
