### PR TITLE
fix(youtube): clarify missing player response errors

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1382,11 +1382,14 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 }
             }
 
+            if (playerResponse == null) {
+                throw new ContentNotAvailableException(
+                        "Could not fetch a usable YouTube player response. Try logging in.");
+            }
+
         // Check playability status from the actual stream data source
-        if (playerResponse != null) {
-            checkPlayabilityStatus(playerResponse.getObject("playabilityStatus"), videoId);
-            setStreamType();
-        }
+        checkPlayabilityStatus(playerResponse.getObject("playabilityStatus"), videoId);
+        setStreamType();
 
         if (streamType != StreamType.LIVE_STREAM && isSabrOnlyResponse()
                 && getHlsManifestUrlFromStreamingData().isEmpty()) {
@@ -1417,8 +1420,6 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         }
         return false;
     }
-
-
 
     public static JsonObject checkPlayabilityStatus(@Nonnull JsonObject playabilityStatus, String videoId)
             throws ParsingException {
@@ -1478,6 +1479,10 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                             "This video is not available in client's country.");
                 } else {
                     if(detailedErrorMessage != null) {
+                        if (detailedErrorMessage.contains("page needs to be reloaded")) {
+                            throw new ContentNotAvailableException(detailedErrorMessage
+                                    + " Try logging in.");
+                        }
                         throw new ContentNotAvailableException(detailedErrorMessage);
                     }
                     throw new ContentNotAvailableException(reason);
@@ -1504,8 +1509,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
      * object.
      */
     private CancellableCall fetchAndroidVRJsonPlayer(@Nonnull final ContentCountry contentCountry,
-                                              @Nonnull final Localization localization,
-                                              @Nonnull final String videoId)
+                                               @Nonnull final Localization localization,
+                                               @Nonnull final String videoId)
             throws IOException, ExtractionException {
         androidCpn = generateContentPlaybackNonce();
         final InnertubeClientRequestInfo innertubeClientRequestInfo =
@@ -1536,15 +1541,16 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         return;
                     }
 
-                    YoutubeStreamExtractor.this.playerResponse = androidPlayerResponse;
-
                     final JsonObject streamingData = androidPlayerResponse.getObject(STREAMING_DATA);
                     if (!isNullOrEmpty(streamingData)) {
+                        YoutubeStreamExtractor.this.playerResponse = androidPlayerResponse;
                         androidStreamingData = streamingData;
                         if (isNullOrEmpty(playerCaptionsTracklistRenderer)) {
                             playerCaptionsTracklistRenderer = androidPlayerResponse.getObject("captions")
                                     .getObject("playerCaptionsTracklistRenderer");
                         }
+                    } else if (YoutubeStreamExtractor.this.playerResponse == null) {
+                        YoutubeStreamExtractor.this.playerResponse = androidPlayerResponse;
                     }
                 } catch (Exception e) {
                     e.printStackTrace();


### PR DESCRIPTION
Context from TypeType issue:

https://github.com/Priveetee/TypeType/issues/72

Related SABR work:

- https://github.com/InfinityLoop1308/PipePipeExtractor/pull/69

Related PipePipe issue:

- https://github.com/InfinityLoop1308/PipePipe/issues/2385

## Summary

TypeType issue #72 surfaced a YouTube extraction failure where the frontend received:

```text
Cannot invoke "com.grack.nanojson.JsonObject.getObject(String)" because "this.playerResponse" is null
```

I reproduced the null `playerResponse` path locally by delaying the player response, then checked the affected Made for Kids / COPPA examples to understand the underlying playback failure.

This PR does not fix playback for those videos. That appears to be in the SABR / login-required area already being explored in #69.

This PR only makes the failure explicit and user-actionable instead of surfacing as a null `playerResponse` crash.

## Problem

`YoutubeStreamExtractor.onFetchPage()` currently skips playability checks when `playerResponse == null`.

If no usable player response was fetched, `fetchPage()` can still return, and later getters such as `getName()` assume `playerResponse` exists.

That turns a YouTube extraction failure into a `NullPointerException`, which makes the real cause harder to understand and harder to surface to users.

## Findings

Tested examples:

```text
https://www.youtube.com/watch?v=8KtnrtHRiCg
https://www.youtube.com/watch?v=mZuTUz5ilOs
```

Observed locally:

```text
ANDROID_VR: UNPLAYABLE, no streamingData
WEB: UNPLAYABLE, no streamingData
ANDROID / WEB_EMBED: streamingData present, but no usable stream URLs
```

There is a possible workaround using the Safari player response. In local testing it returned progressive streams for the affected videos.

I am intentionally not adding that fallback here because I do not like the tradeoff: it is fragile, it changes stream selection behavior, and it would paper over the actual SABR-related issue instead of fixing it.

The long-term fix is likely in the SABR area, which is already being explored in #69. Until then, affected users should try logging in if they need an immediate workaround.

## Changes

- Throw a normal extraction exception when no usable YouTube player response was fetched.
- Include `Try logging in.` in the error shown for this failure path.
- Include `Try logging in.` when YouTube returns the `page needs to be reloaded` error.
- Avoid exposing the internal null `playerResponse` crash to users.

## Validation

- `git diff --check`
- `./gradlew :extractor:compileJava --no-daemon`
- Reproduced the original null `playerResponse` crash with a delayed player response.
- Verified the same path now returns:

```text
Could not fetch a usable YouTube player response. Try logging in.
```

- Verified the real COPPA sample now returns:

```text
The page needs to be reloaded. Try logging in.
```

- Verified a normal YouTube video still extracts streams:

```text
https://www.youtube.com/watch?v=dQw4w9WgXcQ

audio=4
video=1
videoOnly=18
errors=0
```

## Notes

This does not implement SABR playback and does not add a Safari fallback.

The affected COPPA/SABR cases still require SABR support or login/tokens. This PR only improves the failure mode and tells users to try logging in instead of surfacing an internal null crash.
