### PR TITLE
fix(youtube): preserve playlist video uploaders

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubePlaylistExtractor.java
@@ -487,12 +487,32 @@ public class YoutubePlaylistExtractor extends PlaylistExtractor {
         collector.commit(new YoutubeLockupStreamInfoItemExtractor(lockupViewModel, timeAgoParser) {
             @Override
             public String getUploaderName() throws ParsingException {
-                return fallbackName == null ? super.getUploaderName() : fallbackName;
+                if (fallbackName == null) {
+                    return super.getUploaderName();
+                }
+                try {
+                    final String uploaderName = super.getUploaderName();
+                    if (!isNullOrEmpty(uploaderName)) {
+                        return uploaderName;
+                    }
+                } catch (final ParsingException ignored) {
+                }
+                return fallbackName;
             }
 
             @Override
             public String getUploaderUrl() throws ParsingException {
-                return fallbackUrl == null ? super.getUploaderUrl() : fallbackUrl;
+                if (fallbackUrl == null) {
+                    return super.getUploaderUrl();
+                }
+                try {
+                    final String uploaderUrl = super.getUploaderUrl();
+                    if (!isNullOrEmpty(uploaderUrl)) {
+                        return uploaderUrl;
+                    }
+                } catch (final ParsingException ignored) {
+                }
+                return fallbackUrl;
             }
         });
     }


### PR DESCRIPTION
Found while working on TypeType public YouTube playlist support:

https://github.com/Priveetee/TypeType/issues/106

## Summary

While working on public YouTube playlists for TypeType, I found that mixed YouTube playlists can report the playlist owner as the uploader for every video on the initial playlist page.

This fixes YouTube playlist `lockupViewModel` entries overriding the per-video uploader with the playlist uploader whenever the playlist uploader fallback is available.

## Problem

The playlist page can expose the correct uploader per video through `YoutubeLockupStreamInfoItemExtractor`.

However, `YoutubePlaylistExtractor` currently wraps lockup video items and returns the playlist uploader whenever `fallbackName` / `fallbackUrl` exists:

```text
video uploader = playlist uploader
```

Observed on a public YouTube playlist:

```text
https://www.youtube.com/playlist?list=PLMC9KNkIncKtPzgY-5rmhvj7fax8fdxoj
```

Before this change, the first page returned different videos with the same uploader:

```text
Lady Gaga, Bruno Mars - Die With A Smile | ka-Redlist - Just Hits
DJ Snake - Let Me Love You | ka-Redlist - Just Hits
Michael Jackson - Thriller | ka-Redlist - Just Hits
```

## Changes

- Keep the uploader parsed from each `YoutubeLockupStreamInfoItemExtractor` when available.
- Use the playlist uploader name/url only as a fallback when the video uploader cannot be parsed.
- Keep the change limited to YouTube playlist lockup video items.

## Validation

- `JAVA_HOME=/usr/lib/jvm/java-25-openjdk ./gradlew :extractor:compileJava`
- Local extractor smoke against:

```text
https://www.youtube.com/playlist?list=PLMC9KNkIncKtPzgY-5rmhvj7fax8fdxoj
```

After:

```text
playlist=ka-Redlist - Just Hits
Lady Gaga, Bruno Mars - Die With A Smile | Lady Gaga
DJ Snake - Let Me Love You | DJ Snake
Michael Jackson - Thriller | Michael Jackson
ROSÉ & Bruno Mars - APT. | ROSÉ
Madison Beer - lovergirl | Madison Beer
```

## Notes

This keeps the playlist uploader fallback behavior for cases where YouTube does not expose a video uploader, but avoids replacing valid per-video uploader metadata.
