### PR TITLE
fix(youtube): read the sort token from the dropdown chip on channels using it

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -205,6 +205,42 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
             throw new ParsingException("YouTube channel tab sort filter is not available");
         }
 
+        // Some channels expose the sort options as a single "Sort by" dropdown chip
+        // (displayType = CHIP_VIEW_MODEL_DISPLAY_TYPE_DROP_DOWN). The actual Latest/Popular/Oldest
+        // tokens then live inside that chip's sheet listItems, not in the chipBar directly.
+        // Reading chips[sortIndex] in that case picked filter chips (e.g. "Members only", "Public")
+        // and returned their continuation tokens, so the sort never applied.
+        if (!chips.isEmpty()) {
+            final JsonObject firstChip = chips.getObject(0).getObject("chipViewModel");
+            if ("CHIP_VIEW_MODEL_DISPLAY_TYPE_DROP_DOWN".equals(firstChip.getString("displayType"))) {
+                final JsonArray listItems = firstChip
+                        .getObject("tapCommand")
+                        .getObject("innertubeCommand")
+                        .getObject("showSheetCommand")
+                        .getObject("panelLoadingStrategy")
+                        .getObject("inlineContent")
+                        .getObject("sheetViewModel")
+                        .getObject("content")
+                        .getObject("listViewModel")
+                        .getArray("listItems");
+                if (listItems.size() <= sortIndex) {
+                    throw new ParsingException("YouTube channel tab sort filter is not available");
+                }
+                final String token = extractContinuationTokenFromListItem(
+                        listItems.getObject(sortIndex).getObject("listItemViewModel"));
+                if (isNullOrEmpty(token)) {
+                    throw new ParsingException(
+                            "Could not get YouTube channel tab sort continuation");
+                }
+                return token;
+            }
+        }
+
+        // Flat format: chips[sortIndex] is itself the sort chip.
+        if (chips.size() <= sortIndex) {
+            throw new ParsingException("YouTube channel tab sort filter is not available");
+        }
+
         final String token = chips.getObject(sortIndex)
                 .getObject("chipViewModel")
                 .getObject("tapCommand")
@@ -217,6 +253,39 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         }
 
         return token;
+    }
+
+    /**
+     * Walks a sort-dropdown listItem to find its continuationCommand token.
+     * The token lives inside {@code commandExecutorCommand.commands[]} (typically alongside an
+     * entityUpdateCommand for the chip state). We scan the commands array instead of guessing
+     * an index because other commands can sit before the continuationCommand.
+     */
+    @Nullable
+    private static String extractContinuationTokenFromListItem(
+            @Nonnull final JsonObject listItemViewModel) {
+        final JsonObject innertube = listItemViewModel
+                .getObject("rendererContext")
+                .getObject("commandContext")
+                .getObject("onTap")
+                .getObject("innertubeCommand");
+        final JsonObject executor = innertube.getObject("commandExecutorCommand");
+        if (executor == null) {
+            return null;
+        }
+        final JsonArray commands = executor.getArray("commands");
+        for (final Object o : commands) {
+            final JsonObject command = (JsonObject) o;
+            if (command.has("continuationCommand")) {
+                final String token = command
+                        .getObject("continuationCommand")
+                        .getString("token");
+                if (!isNullOrEmpty(token)) {
+                    return token;
+                }
+            }
+        }
+        return null;
     }
 
     private int getSelectedSortFilterIndex() throws ParsingException {


### PR DESCRIPTION
Refs https://github.com/InfinityLoop1308/PipePipe/issues/2549

## Commits
- https://github.com/Priveetee/PipePipeExtractor/commit/88e1f0e

## Summary
- Fix YouTube channel **Videos** tab sorting (`latest` / `popular` / `oldest`) being silently ignored on a subset of channels.
- YouTube now serves the sort chips as a single "Sort by" dropdown on those channels, with the real sort tokens hidden inside its sheet. The extractor was reading the chipBar by index and picked up "Members only" / "Public" filter tokens instead of sort tokens.
- Keep the existing flat chipBar layout working unchanged.

## Problem
YouTube rolled out a second chipBar layout on the channel Videos tab. Two layouts now coexist:

```text
flat (still common):   chips = [Latest, Popular, Oldest], each with a direct continuationCommand.token
dropdown (new):        chips = [SortBy (DROP_DOWN), MembersOnly, Public]
                       sort tokens live in SortBy.tapCommand.showSheetCommand.sheetViewModel.listViewModel.listItems[]
```

`getSortContinuationToken` did `chips.getObject(sortIndex)` with `latest=0 / popular=1 / oldest=2`. On the dropdown layout, index 1 is the "Members only" filter and index 2 is the "Public" filter, so `popular` loaded members-only videos and `oldest` loaded public-filter videos in the default order.

Observed on one of the reported channels (`UCfMaMDIYLcZbN2aagsTUO5Q`), first five video IDs per sort:

```text
before:
latest   = gBBZSFojEno qevwjRTW7HQ 4xNd3jhMVUQ bMaHJf9M9BI ZRK4UjqN5w8
popular  = (0 items)
oldest   = gBBZSFojEno qevwjRTW7HQ 4xNd3jhMVUQ bMaHJf9M9BI ZRK4UjqN5w8
```

## Changes
- `YoutubeChannelTabExtractor#getSortContinuationToken`: when the first chip is `CHIP_VIEW_MODEL_DISPLAY_TYPE_DROP_DOWN`, read the sort token from its sheet `listItems[sortIndex]` instead of `chips[sortIndex]`.
- Add `extractContinuationTokenFromListItem` to pull `continuationCommand.token` out of `commandExecutorCommand.commands[]` (it sits next to an `entityUpdateCommand`, so no hardcoded command index).
- Flat-layout path untouched.

## Validation
- `./gradlew :extractor:compileJava`
- Local extractor probe against reported channels with the dropdown layout.

After, same channel:

```text
latest   = gBBZSFojEno qevwjRTW7HQ 4xNd3jhMVUQ bMaHJf9M9BI ZRK4UjqN5w8
popular  = cQ7X8VEiCko QAan0CmkYEA 33v-L43JCeo gBBZSFojEno 0h6Ig83cjPw
oldest   = -b22efhXG7I SqmxRfFj318 X5v_yfcI0k0 xoQO7XroBko ZJ6xFPY3wJA
```

Also probed three more reported dropdown channels (`UC9YOQFPfEUXbulKDtxeqqBA`, `UCpPQTM5BojSeZJC_Q-vvs5A`, `UCKAmgxBSTqfSGz6OPxhrCZA`): all three sorts return distinct item orders after the fix.

No regression on a flat-layout channel (`UCBJycsmduvYEL83R_U4JriQ`): latest / popular / oldest stay distinct, same as before.

## Notes
- Relies on the dropdown `listItems` order being `[Latest, Popular, Oldest]`, which matched every channel I captured and matches YouTube's UI. If YouTube reorders it, the helper returns null and we throw a clean `ParsingException` instead of silently loading the wrong content.
- This only touches the Videos tab chipBar. `#2546` (channel search "Could not get url") is a separate bug on the search path and is not addressed here.