### PR TITLE
fix(youtube): avoid SABR OOM from segment buffer growth

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaSegmentCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaSegmentCollector.java
@@ -77,7 +77,7 @@ public final class SabrMediaSegmentCollector {
             openSegments.put(header.getHeaderId(), new OpenSegment(header));
         }
 
-        public void onMedia(@Nonnull final byte[] partData) {
+        public void onMedia(@Nonnull final byte[] partData) throws SabrProtocolException {
             if (partData.length > 0) {
                 final OpenSegment openSegment = openSegments.get(partData[0] & 0xff);
                 if (openSegment != null) {
@@ -102,24 +102,60 @@ public final class SabrMediaSegmentCollector {
     private static final class OpenSegment {
         @Nonnull
         private final SabrMediaHeader header;
-        private final ByteArrayOutputStream data = new ByteArrayOutputStream();
+        @Nullable
+        private final byte[] fixedData;
+        @Nullable
+        private final ByteArrayOutputStream dynamicData;
+        private int length;
 
-        private OpenSegment(@Nonnull final SabrMediaHeader header) {
+        private OpenSegment(@Nonnull final SabrMediaHeader header) throws SabrProtocolException {
             this.header = header;
+            final long contentLength = header.getContentLength();
+            if (contentLength >= 0) {
+                if (contentLength > Integer.MAX_VALUE) {
+                    throw new SabrProtocolException("SABR media segment too large: headerId="
+                            + header.getHeaderId() + ", length=" + contentLength);
+                }
+                fixedData = new byte[(int) contentLength];
+                dynamicData = null;
+            } else {
+                fixedData = null;
+                dynamicData = new ByteArrayOutputStream();
+            }
         }
 
-        private void write(@Nonnull final byte[] bytes, final int offset, final int length) {
-            data.write(bytes, offset, length);
+        private void write(@Nonnull final byte[] bytes, final int offset, final int count)
+                throws SabrProtocolException {
+            if (count <= 0) {
+                return;
+            }
+            if (fixedData != null) {
+                if (length + count > fixedData.length) {
+                    throw new SabrProtocolException("SABR media length overflow: headerId="
+                            + header.getHeaderId()
+                            + ", expected=" + fixedData.length
+                            + ", actual>=" + (length + count));
+                }
+                System.arraycopy(bytes, offset, fixedData, length, count);
+            } else {
+                dynamicData.write(bytes, offset, count);
+            }
+            length += count;
         }
 
         @Nonnull
         private SabrMediaSegment toSegment() throws SabrProtocolException {
-            final byte[] rawBytes = data.toByteArray();
-            if (header.getContentLength() >= 0 && rawBytes.length != header.getContentLength()) {
+            final byte[] rawBytes;
+            if (fixedData != null) {
+                rawBytes = fixedData;
+            } else {
+                rawBytes = dynamicData.toByteArray();
+            }
+            if (header.getContentLength() >= 0 && length != header.getContentLength()) {
                 throw new SabrProtocolException("SABR media length mismatch: headerId="
                         + header.getHeaderId()
                         + ", expected=" + header.getContentLength()
-                        + ", actual=" + rawBytes.length);
+                        + ", actual=" + length);
             }
             return new SabrMediaSegment(header, maybeDecompress(header, rawBytes));
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/UmpReader.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/UmpReader.java
@@ -29,6 +29,7 @@ public final class UmpReader {
                                      @Nonnull final PartConsumer consumer)
             throws SabrProtocolException, IOException {
         while (true) {
+            throwIfInterrupted();
             final int first = in.read();
             if (first < 0) {
                 return; // clean EOF at a part boundary -> done
@@ -67,6 +68,7 @@ public final class UmpReader {
 
     private static int readByteOrThrow(@Nonnull final InputStream in)
             throws SabrProtocolException, IOException {
+        throwIfInterrupted();
         final int b = in.read();
         if (b < 0) {
             throw new SabrProtocolException("Unexpected EOF in UMP integer");
@@ -80,9 +82,11 @@ public final class UmpReader {
         if (length < 0) {
             throw new SabrProtocolException("Invalid UMP part length");
         }
+        throwIfInterrupted();
         final byte[] result = new byte[length];
         int offset = 0;
         while (offset < length) {
+            throwIfInterrupted();
             final int read = in.read(result, offset, length - offset);
             if (read < 0) {
                 throw new SabrProtocolException("Unexpected EOF while reading UMP part data");
@@ -90,6 +94,12 @@ public final class UmpReader {
             offset += read;
         }
         return result;
+    }
+
+    private static void throwIfInterrupted() throws IOException {
+        if (Thread.currentThread().isInterrupted()) {
+            throw new IOException("Interrupted while reading UMP stream");
+        }
     }
 
     @Nonnull


### PR DESCRIPTION
Part of https://github.com/InfinityLoop1308/PipePipe/issues/2577

Pairs with the client-side SABR lifecycle/cache fix: InfinityLoop1308/PipePipeClient#64

## Summary

Rapid playlist skipping with SABR could still hit an OOM even after bounding the session cache. The crash report showed the remaining allocation spike was inside `SabrMediaSegmentCollector.OpenSegment.write()`, where `ByteArrayOutputStream` grows by allocating a larger backing array while the old one is still live.

This makes SABR segment assembly use an exact-sized buffer when the media header exposes `contentLength`, and makes the streaming UMP reader stop promptly when its pump thread is interrupted.

## Problem

Crash report from the 120-skip repro:

```text
java.lang.OutOfMemoryError: Failed to allocate a 16777232 byte allocation
    at java.util.Arrays.copyOf(Arrays.java:4276)
    at java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
    at org.schabi.newpipe.extractor.services.youtube.sabr.SabrMediaSegmentCollector$OpenSegment.write(...)
    at org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrSession.pumpOnce(...)
```

The cache byte limit only applies after a segment has been collected and inserted. During collection, `ByteArrayOutputStream` can temporarily require the old buffer + the new grown buffer + the incoming UMP part at the same time. Under rapid skips, old SABR pumps can also still be interrupted while reading a large UMP payload.

## Changes

- `SabrMediaSegmentCollector.OpenSegment`: when `contentLength` is known, allocate one exact `byte[]` and copy media payloads into it directly.
- Detect media length overflow/mismatch as `SabrProtocolException` instead of growing until the heap fails.
- Keep the dynamic `ByteArrayOutputStream` fallback only for segments without `contentLength`.
- `UmpReader.readStreaming`: check thread interruption before reading/allocating the next UMP payload and while reading large payloads.

## Validation

- `./gradlew :extractor:compileJava`
- `./gradlew :app:assembleDebug` from PipePipeClient, with this extractor substituted through `includeBuild`.
- Installed debug APK on Pixel 8.
- Reproduced the original issue first:
  - SABR forced.
  - Large YouTube playlist.
  - Background playback.
  - Rapid `MEDIA_NEXT`.
  - OOM reproduced before the final extractor fix, with Java heap RSS around `567412 KB`.
- After this change plus the paired client fix:
  - 120 `MEDIA_NEXT` commands sent.
  - `MediaSourceManager`: 100 source loads, 119 reloads.
  - No `OutOfMemory`, no `FATAL EXCEPTION`, no `Failed to allocate`.
  - Max Java heap observed: `149648 KB RSS`.

## Notes

This does not change SABR request semantics or cache policy. It only removes avoidable transient allocation pressure while assembling a response segment and lets abandoned pump reads stop earlier.