### PR TITLE
fix(youtube): respect active SABR tracks on cold start

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrRequestBuilder.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrRequestBuilder.java
@@ -34,7 +34,10 @@ final class YoutubeSabrRequestBuilder {
 
         final SabrProto.Writer request = new SabrProto.Writer();
         request.writeMessage(1, buildClientAbrState(audioFormat, videoFormat, 0, false,
-                ENABLED_TRACK_TYPES_VIDEO_AND_AUDIO, streamState));
+                streamState == null
+                        ? ENABLED_TRACK_TYPES_VIDEO_AND_AUDIO
+                        : streamState.getEnabledTrackTypesBitfield(),
+                streamState));
         request.writeBytes(5, decodeBase64(ustreamerConfig));
         writePreferredFormats(request, info, audioFormat, videoFormat, streamState);
         request.writeMessage(19, streamState == null
@@ -221,19 +224,23 @@ final class YoutubeSabrRequestBuilder {
                 return;
             }
             for (final YoutubeSabrFormat format : info.getFormats()) {
-                if (format.isAudio()) {
+                if (format.isAudio() && streamState.shouldSelectAudioFormat()) {
                     request.writeMessage(16, SabrProto.formatId(format));
                 }
             }
             for (final YoutubeSabrFormat format : info.getFormats()) {
-                if (format.isVideo()) {
+                if (format.isVideo() && streamState.shouldSelectVideoFormat()) {
                     request.writeMessage(17, SabrProto.formatId(format));
                 }
             }
             return;
         }
-        request.writeMessage(16, SabrProto.formatId(audioFormat));
-        request.writeMessage(17, SabrProto.formatId(videoFormat));
+        if (streamState == null || streamState.shouldSelectAudioFormat()) {
+            request.writeMessage(16, SabrProto.formatId(audioFormat));
+        }
+        if (streamState == null || streamState.shouldSelectVideoFormat()) {
+            request.writeMessage(17, SabrProto.formatId(videoFormat));
+        }
     }
 
     private static void writeOfficialWebPreferredFormats(@Nonnull final SabrProto.Writer request,


### PR DESCRIPTION
Part of https://github.com/InfinityLoop1308/PipePipe/issues/2575

Pairs with the client-side lockscreen/background fix: https://github.com/InfinityLoop1308/PipePipeClient/pull/70

## Summary

While testing the Android 17 lockscreen issue, I found one SABR-side problem in the background/audio-only path.

Follow-up SABR requests already respected the active track state, but the first media request still behaved like audio + video were selected. In background playback this can make the session start with the wrong shape.

This makes the cold-start request respect the active SABR track types too.

## Changes

- Use the stream state's enabled track bitfield for the first media request.
- Only write preferred audio formats when audio is active.
- Only write preferred video formats when video is active.
- Treat incomplete media-only SABR responses as recoverable and retry/reload instead of killing the session immediately.

## Validation

Tested with the paired client patch on Pixel 8 / Android 17:

- foreground playback
- background audio
- lockscreen play/pause
- lockscreen seek backward / forward
- queue transition after lockscreen seek

Build:

- `./gradlew :extractor:compileJava`
- `git diff --check`