### PR TITLE
fix(youtube): support logged-in age-restricted streams through TV fallback

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -213,6 +213,8 @@ YoutubeParsingHelper {
     private static final String[] INITIAL_DATA_REGEXES =
             {"window\\[\"ytInitialData\"\\]\\s*=\\s*(\\{.*?\\});",
                     "var\\s*ytInitialData\\s*=\\s*(\\{.*?\\});"};
+    private static final String[] YTCFG_REGEXES =
+            {"ytcfg\\.set\\s*\\(\\s*(\\{.+?\\})\\s*\\)\\s*;"};
     private static final String CONTENT_PLAYBACK_NONCE_ALPHABET =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
@@ -1795,6 +1797,37 @@ YoutubeParsingHelper {
         }
     }
 
+    @Nonnull
+    public static JsonObject getWebWatchYtcfg(@Nonnull final String videoId)
+            throws IOException, ExtractionException {
+        final Map<String, List<String>> headers = new HashMap<>(getCookieHeader());
+        if (ServiceList.YouTube.hasTokens()) {
+            headers.put("Cookie", singletonList(ServiceList.YouTube.getTokens()));
+        }
+        headers.put("User-Agent", singletonList(WEB_USER_AGENT));
+
+        final String html = getDownloader().get(
+                "https://www.youtube.com/watch?v=" + videoId, headers).responseBody();
+        final JsonObject mergedYtcfg = new JsonObject();
+        final java.util.regex.Matcher matcher = Pattern.compile(YTCFG_REGEXES[0]).matcher(html);
+        while (matcher.find()) {
+            try {
+                final JsonObject ytcfg = JsonParser.object().from(matcher.group(1));
+                mergedYtcfg.putAll(ytcfg);
+                if (!isNullOrEmpty(mergedYtcfg.getString("VISITOR_DATA", ""))
+                        && mergedYtcfg.get("SESSION_INDEX") != null) {
+                    return mergedYtcfg;
+                }
+            } catch (final JsonParserException ignored) {
+                // Some pages include small ytcfg fragments; keep looking for the full config.
+            }
+        }
+        if (!mergedYtcfg.isEmpty()) {
+            return mergedYtcfg;
+        }
+        throw new ParsingException("Could not get ytcfg");
+    }
+
     /**
      * Returns a {@link Map} containing the required YouTube Music headers.
      */
@@ -2411,20 +2444,32 @@ YoutubeParsingHelper {
         String ytURL = "https://www.youtube.com";
 
         Map<String, String> cookies = parseCookies(cookie);
-        String sapisid = cookies.get("SAPISID");
+        final List<String> authorizations = new ArrayList<>();
 
-        if (sapisid == null) {
-            sapisid = cookies.get("__Secure-3PAPISID");
-            if (sapisid == null) {
-                throw new IllegalArgumentException("SAPISID not found in cookies");
-            }
+        appendAuthorization(authorizations, "SAPISIDHASH", cookies.get("SAPISID"), ytURL);
+        appendAuthorization(authorizations, "SAPISID1PHASH", cookies.get("__Secure-1PAPISID"), ytURL);
+        appendAuthorization(authorizations, "SAPISID3PHASH", cookies.get("__Secure-3PAPISID"), ytURL);
+
+        if (authorizations.isEmpty()) {
+            throw new IllegalArgumentException("SAPISID not found in cookies");
         }
 
+        return String.join(" ", authorizations);
+    }
+
+    private static void appendAuthorization(@Nonnull final List<String> authorizations,
+                                            @Nonnull final String scheme,
+                                            @Nullable final String sid,
+                                            @Nonnull final String ytURL)
+            throws NoSuchAlgorithmException {
+        if (isNullOrEmpty(sid)) {
+            return;
+        }
         long currentTimestamp = Instant.now().getEpochSecond();
-        String initialData = currentTimestamp + " " + sapisid + " " + ytURL;
+        String initialData = currentTimestamp + " " + sid + " " + ytURL;
         String hash = sha1(initialData);
 
-        return "SAPISIDHASH " + currentTimestamp + "_" + hash;
+        authorizations.add(scheme + " " + currentTimestamp + "_" + hash);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -2228,6 +2228,84 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         return itagInfo;
     }
 
+    private void batchDeobfuscateItagUrls(@Nonnull final String videoId,
+                                          @Nonnull final List<ItagInfo> itagInfoList)
+            throws ParsingException {
+        if (itagInfoList.isEmpty()) {
+            return;
+        }
+
+        final LinkedHashSet<String> uniqueSignatures = new LinkedHashSet<>();
+        final LinkedHashSet<String> uniqueThrottlingParams = new LinkedHashSet<>();
+        final List<StreamDeobfuscationInfo> streamInfos = new ArrayList<>();
+
+        for (int i = 0; i < itagInfoList.size(); i++) {
+            final ItagInfo itagInfo = itagInfoList.get(i);
+            final String url = itagInfo.getContent();
+            final String obfuscatedSignature = itagInfo.getObfuscatedSignature();
+            final String throttlingParam =
+                    YoutubeJavaScriptPlayerManager.getThrottlingParameterFromStreamingUrl(url);
+
+            streamInfos.add(new StreamDeobfuscationInfo(i, obfuscatedSignature, throttlingParam));
+            if (!isNullOrEmpty(obfuscatedSignature)) {
+                uniqueSignatures.add(obfuscatedSignature);
+            }
+            if (!isNullOrEmpty(throttlingParam)) {
+                uniqueThrottlingParams.add(throttlingParam);
+            }
+        }
+
+        if (uniqueSignatures.isEmpty() && uniqueThrottlingParams.isEmpty()) {
+            return;
+        }
+
+        final YoutubeApiDecoder.BatchDecodeResult result =
+                YoutubeJavaScriptPlayerManager.deobfuscateBatch(
+                        videoId,
+                        new ArrayList<>(uniqueSignatures),
+                        new ArrayList<>(uniqueThrottlingParams));
+
+        final Map<String, String> decodedSignatures = result.getSignatures();
+        final Map<String, String> decodedThrottling = result.getNParameters();
+
+        for (final StreamDeobfuscationInfo info : streamInfos) {
+            final ItagInfo itagInfo = itagInfoList.get(info.streamIndex);
+            String updatedUrl = itagInfo.getContent();
+
+            if (!isNullOrEmpty(info.obfuscatedSignature)) {
+                final String deobfuscatedSig = decodedSignatures.get(info.obfuscatedSignature);
+                if (deobfuscatedSig != null) {
+                    updatedUrl = updatedUrl.replace("SIGNATURE_PLACEHOLDER", deobfuscatedSig);
+                }
+            }
+
+            if (!isNullOrEmpty(info.throttlingParam)) {
+                final String deobfuscatedParam = decodedThrottling.get(info.throttlingParam);
+                if (deobfuscatedParam != null) {
+                    updatedUrl = updatedUrl.replace(info.throttlingParam, deobfuscatedParam);
+                }
+            }
+
+            itagInfo.setContent(updatedUrl);
+        }
+    }
+
+    private static class StreamDeobfuscationInfo {
+        private final int streamIndex;
+        @Nullable
+        private final String obfuscatedSignature;
+        @Nullable
+        private final String throttlingParam;
+
+        StreamDeobfuscationInfo(final int streamIndex,
+                                @Nullable final String obfuscatedSignature,
+                                @Nullable final String throttlingParam) {
+            this.streamIndex = streamIndex;
+            this.obfuscatedSignature = obfuscatedSignature;
+            this.throttlingParam = throttlingParam;
+        }
+    }
+
 
     /*//////////////////////////////////////////////////////////////////////////
     // Utils

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -82,6 +82,8 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Nullable
     private JsonObject mwebStreamingData;
     @Nullable
+    private JsonObject tvStreamingData;
+    @Nullable
     private JsonObject configuredStreamingData;
 
     private JsonObject videoPrimaryInfoRenderer;
@@ -98,6 +100,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     // two different strings are used.
     private String webCpn;
     private String mwebCpn;
+    private String tvCpn;
 
     public WatchDataCache watchDataCache;
 
@@ -298,7 +301,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             return Long.parseLong(duration);
         } catch (final Exception e) {
             return getDurationFromFirstAdaptiveFormat(Arrays.asList(
-                    webStreamingData, mwebStreamingData));
+                    webStreamingData, mwebStreamingData, tvStreamingData));
         }
     }
 
@@ -716,7 +719,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
         String hlsUrl = getManifestUrl(
                 "hls",
-                Arrays.asList(webStreamingData, mwebStreamingData));
+                Arrays.asList(webStreamingData, mwebStreamingData, tvStreamingData));
 
         if (!hlsUrl.isEmpty()) {
             hlsUrl = deobfuscateManifestUrl(hlsUrl);
@@ -993,7 +996,7 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     @Nonnull
     private String getHlsManifestUrlFromStreamingData() {
         for (final JsonObject sd : Arrays.asList(
-                webStreamingData, mwebStreamingData)) {
+                webStreamingData, mwebStreamingData, tvStreamingData)) {
             if (sd != null) {
                 final String url = sd.getString("hlsManifestUrl");
                 if (url != null && !url.isEmpty()) {
@@ -1569,11 +1572,18 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             };
             awaitRequiredCalls(requiredCalls, ServiceList.YouTube.getLoadingTimeout());
 
+            if ((playerResponse == null || (webStreamingData == null && mwebStreamingData == null))
+                    && ServiceList.YouTube.hasTokens()) {
+                fetchTvDowngradedJsonPlayer(contentCountry, localization, videoId);
+            }
+            if (tvStreamingData != null) {
+                removeLoggedInAgeGateErrorsAfterTvFallback();
+            }
             throwIfErrors();
             if (playerResponse == null) {
                 throw new ExtractionException("YouTube player response is missing");
             }
-            if (webStreamingData == null && mwebStreamingData == null) {
+            if (webStreamingData == null && mwebStreamingData == null && tvStreamingData == null) {
                 throw new ExtractionException("YouTube streaming data is missing");
             }
             if (nextResponse == null) {
@@ -1614,6 +1624,14 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             if (!call.isFinished()) {
                 call.cancel();
             }
+        }
+    }
+
+    private void removeLoggedInAgeGateErrorsAfterTvFallback() {
+        synchronized (errors) {
+            errors.removeIf(error -> error instanceof AgeRestrictedContentException
+                    && error.getMessage() != null
+                    && error.getMessage().contains("anonymously"));
         }
     }
 
@@ -1824,6 +1842,97 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                         mwebCpn,
                         "MWEB",
                         MWEB_USER_AGENT), localization, "2", MWEB_USER_AGENT, callback);
+    }
+
+    private void fetchTvDowngradedJsonPlayer(@Nonnull final ContentCountry contentCountry,
+                                             @Nonnull final Localization localization,
+                                             @Nonnull final String videoId)
+            throws IOException, ExtractionException {
+        if (!ServiceList.YouTube.hasTokens()) {
+            return;
+        }
+
+        tvCpn = generateContentPlaybackNonce();
+        final JsonObject ytcfg = getWebWatchYtcfg(videoId);
+        final String visitorData = ytcfg.getString("VISITOR_DATA", EMPTY_STRING);
+        final Object sessionIndexObject = ytcfg.get("SESSION_INDEX");
+        final String sessionIndex = sessionIndexObject == null
+                ? EMPTY_STRING : String.valueOf(sessionIndexObject);
+
+        final byte[] body = JsonWriter.string(
+                        JsonObject.builder()
+                                .object("context")
+                                    .object("client")
+                                        .value("clientName", "TVHTML5")
+                                        .value("clientVersion", "5.20260114")
+                                        .value("hl", localization.getLocalizationCode())
+                                        .value("gl", contentCountry.getCountryCode())
+                                        .value("timeZone", "UTC")
+                                        .value("userAgent", "Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version")
+                                        .value("utcOffsetMinutes", 0)
+                                    .end()
+                                    .object("request")
+                                        .array("internalExperimentFlags")
+                                        .end()
+                                        .value("useSsl", true)
+                                    .end()
+                                    .object("user")
+                                        .value("lockedSafetyMode", false)
+                                    .end()
+                                .end()
+                                .object("playbackContext")
+                                    .object("contentPlaybackContext")
+                                        .value("html5Preference", "HTML5_PREF_WANTS")
+                                        .value("signatureTimestamp",
+                                                YoutubeJavaScriptPlayerManager.getSignatureTimestamp(videoId))
+                                    .end()
+                                .end()
+                                .value(VIDEO_ID, videoId)
+                                .value(CONTENT_CHECK_OK, true)
+                                .value(RACY_CHECK_OK, true)
+                                .done())
+                .getBytes(StandardCharsets.UTF_8);
+
+        final Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", singletonList("application/json"));
+        headers.put("User-Agent", singletonList("Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version"));
+        headers.put("Origin", singletonList("https://www.youtube.com"));
+        headers.put("X-YouTube-Client-Name", singletonList("7"));
+        headers.put("X-YouTube-Client-Version", singletonList("5.20260114"));
+        addLoggedInHeaders(headers);
+        if (!isNullOrEmpty(visitorData)) {
+            headers.put("X-Goog-Visitor-Id", singletonList(visitorData));
+        }
+        if (!isNullOrEmpty(sessionIndex)) {
+            headers.put("X-Goog-AuthUser", singletonList(sessionIndex));
+        }
+
+        final Response response = NewPipe.getDownloader().post(
+                YOUTUBEI_V1_URL + PLAYER + "?" + DISABLE_PRETTY_PRINT_PARAMETER,
+                headers, body, localization);
+        final JsonObject tvPlayerResponse =
+                JsonUtils.toJsonObject(getValidJsonResponseBody(response));
+        if (isPlayerResponseNotValid(tvPlayerResponse, videoId)) {
+            throw new ExtractionException("TV player response is not valid");
+        }
+
+        final JsonObject streamingData = tvPlayerResponse.getObject(STREAMING_DATA);
+        if (!isNullOrEmpty(streamingData)) {
+            if (playerResponse == null) {
+                playerResponse = tvPlayerResponse;
+            } else {
+                playerResponse.put("playabilityStatus",
+                        tvPlayerResponse.getObject("playabilityStatus"));
+                playerResponse.put(STREAMING_DATA, streamingData);
+                if (isNullOrEmpty(playerResponse.getObject("videoDetails"))
+                        && !isNullOrEmpty(tvPlayerResponse.getObject("videoDetails"))) {
+                    playerResponse.put("videoDetails", tvPlayerResponse.getObject("videoDetails"));
+                }
+            }
+            updateAvailableAt(playerResponse);
+            tvStreamingData = streamingData;
+            configuredStreamingData = streamingData;
+        }
     }
 
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -39,6 +39,8 @@ import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrInfo;
 import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrProbe;
 import org.schabi.newpipe.extractor.stream.*;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
+import org.schabi.newpipe.extractor.utils.Parser;
+import org.schabi.newpipe.extractor.utils.Pair;
 import org.schabi.newpipe.extractor.utils.SubtitleDeduplicator;
 import org.schabi.newpipe.extractor.utils.Utils;
 
@@ -795,10 +797,75 @@ public class YoutubeStreamExtractor extends StreamExtractor {
                 buildSabrStreams(videoId);
             } else if (streamType == StreamType.POST_LIVE_STREAM) {
                 tryExtractHlsStreams(videoId);
+            } else {
+                buildDirectStreams(videoId);
             }
             streamsCached = true;
         } catch (final Exception e) {
             throw new ParsingException("Could not get streams", e);
+        }
+    }
+
+    private void buildDirectStreams(@Nonnull final String videoId) throws ExtractionException {
+        final List<ItagInfo> allItagInfos = new ArrayList<>();
+        final int audioStartIndex = 0;
+        final int videoStartIndex;
+        final int videoOnlyStartIndex;
+
+        java.util.stream.Stream.of(
+                        new Pair<>(webStreamingData, webCpn),
+                        new Pair<>(mwebStreamingData, mwebCpn),
+                        new Pair<>(tvStreamingData, tvCpn))
+                .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
+                        ADAPTIVE_FORMATS, ItagItem.ItagType.AUDIO, pair.getSecond()))
+                .forEachOrdered(allItagInfos::add);
+
+        videoStartIndex = allItagInfos.size();
+
+        java.util.stream.Stream.of(
+                        new Pair<>(webStreamingData, webCpn),
+                        new Pair<>(mwebStreamingData, mwebCpn),
+                        new Pair<>(tvStreamingData, tvCpn))
+                .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
+                        FORMATS, ItagItem.ItagType.VIDEO, pair.getSecond()))
+                .forEachOrdered(allItagInfos::add);
+
+        videoOnlyStartIndex = allItagInfos.size();
+
+        java.util.stream.Stream.of(
+                        new Pair<>(webStreamingData, webCpn),
+                        new Pair<>(mwebStreamingData, mwebCpn),
+                        new Pair<>(tvStreamingData, tvCpn))
+                .flatMap(pair -> getStreamsFromStreamingDataKey(videoId, pair.getFirst(),
+                        ADAPTIVE_FORMATS, ItagItem.ItagType.VIDEO_ONLY, pair.getSecond()))
+                .forEachOrdered(allItagInfos::add);
+
+        batchDeobfuscateItagUrls(videoId, allItagInfos);
+
+        for (int i = audioStartIndex; i < videoStartIndex; i++) {
+            final AudioStream stream = getAudioStreamBuilderHelper().apply(allItagInfos.get(i));
+            if (!Stream.containSimilarStream(stream, cachedAudioStreams)) {
+                cachedAudioStreams.add(stream);
+            }
+        }
+        Collections.sort(cachedAudioStreams, Comparator.comparingInt(AudioStream::getBitrate).reversed());
+
+        for (int i = videoStartIndex; i < videoOnlyStartIndex; i++) {
+            final VideoStream stream = getVideoStreamBuilderHelper(false).apply(allItagInfos.get(i));
+            if (!Stream.containSimilarStream(stream, cachedVideoStreams)) {
+                cachedVideoStreams.add(stream);
+            }
+        }
+
+        for (int i = videoOnlyStartIndex; i < allItagInfos.size(); i++) {
+            final VideoStream stream = getVideoStreamBuilderHelper(true).apply(allItagInfos.get(i));
+            if (!Stream.containSimilarStream(stream, cachedVideoOnlyStreams)) {
+                cachedVideoOnlyStreams.add(stream);
+            }
+        }
+
+        if (cachedAudioStreams.isEmpty() && cachedVideoOnlyStreams.isEmpty()) {
+            tryExtractHlsStreams(videoId);
         }
     }
 
@@ -1427,9 +1494,12 @@ public class YoutubeStreamExtractor extends StreamExtractor {
     //////////////////////////////////////////////////////////////////////////*/
 
     private static final String ADAPTIVE_FORMATS = "adaptiveFormats";
+    private static final String FORMATS = "formats";
     private static final String STREAMING_DATA = "streamingData";
     private static final String PLAYER = "player";
     private static final String NEXT = "next";
+    private static final String SIGNATURE_CIPHER = "signatureCipher";
+    private static final String CIPHER = "cipher";
 
     private synchronized void updateAvailableAt(@Nonnull final JsonObject response) {
         final double[] waitSeconds = {0};
@@ -1966,6 +2036,196 @@ public class YoutubeStreamExtractor extends StreamExtractor {
             @Nonnull final String videoId) {
         return !videoId.equals(additionalPlayerResponse.getObject("videoDetails")
                 .getString("videoId", ""));
+    }
+
+    @Nonnull
+    private java.util.function.Function<ItagInfo, AudioStream> getAudioStreamBuilderHelper() {
+        return itagInfo -> {
+            final ItagItem itagItem = itagInfo.getItagItem();
+            try {
+                final String randomString = UUID.randomUUID().toString().replaceAll("[^a-zA-Z]", "");
+                final AudioStream.Builder builder = new AudioStream.Builder()
+                        .setAvailableAt(getStreamAvailableAt())
+                        .setId(randomString)
+                        .setContent(itagInfo.getContent()
+                                + (itagInfo.getIsUrl() ? ("&pppid=" + getId()) : ""),
+                                itagInfo.getIsUrl())
+                        .setMediaFormat(itagItem.getMediaFormat())
+                        .setAverageBitrate(itagItem.getAverageBitrate())
+                        .setItagItem(itagItem)
+                        .setAudioTrackId(itagInfo.getAudioTrackId())
+                        .setAudioTrackName(itagInfo.getAudioTrackName())
+                        .setAudioLocale(itagInfo.getAudioLocale());
+
+                if (streamType == StreamType.LIVE_STREAM
+                        || streamType == StreamType.POST_LIVE_STREAM
+                        || !itagInfo.getIsUrl()) {
+                    builder.setDeliveryMethod(DeliveryMethod.DASH);
+                }
+                return builder.build();
+            } catch (final ParsingException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    @Nonnull
+    private java.util.function.Function<ItagInfo, VideoStream> getVideoStreamBuilderHelper(
+            final boolean areStreamsVideoOnly) {
+        return itagInfo -> {
+            final ItagItem itagItem = itagInfo.getItagItem();
+            try {
+                final VideoStream.Builder builder = new VideoStream.Builder()
+                        .setAvailableAt(getStreamAvailableAt())
+                        .setId(String.valueOf(itagItem.id))
+                        .setContent(itagInfo.getContent()
+                                + (itagInfo.getIsUrl() ? ("&pppid=" + getId()) : ""),
+                                itagInfo.getIsUrl())
+                        .setMediaFormat(itagItem.getMediaFormat())
+                        .setIsVideoOnly(areStreamsVideoOnly)
+                        .setItagItem(itagItem);
+
+                final String resolutionString = itagItem.getResolutionString();
+                builder.setResolution(resolutionString != null ? resolutionString : EMPTY_STRING);
+
+                if (streamType != StreamType.VIDEO_STREAM || !itagInfo.getIsUrl()) {
+                    builder.setDeliveryMethod(DeliveryMethod.DASH);
+                }
+                return builder.build();
+            } catch (final ParsingException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    @Nonnull
+    private java.util.stream.Stream<ItagInfo> getStreamsFromStreamingDataKey(
+            final String videoId,
+            @Nullable final JsonObject streamingData,
+            final String streamingDataKey,
+            @Nonnull final ItagItem.ItagType itagTypeWanted,
+            @Nullable final String contentPlaybackNonce) {
+        if (streamingData == null || !streamingData.has(streamingDataKey)) {
+            return java.util.stream.Stream.empty();
+        }
+
+        final String preferredAudioLanguage = ServiceList.YouTube.getAudioLanguage();
+        final String cpn = isNullOrEmpty(contentPlaybackNonce)
+                ? generateContentPlaybackNonce() : contentPlaybackNonce;
+
+        return streamingData.getArray(streamingDataKey).stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
+                .map(formatData -> {
+                    try {
+                        final ItagItem itagItem = ItagItem.getItag(formatData.getInt("itag"));
+                        if (itagItem.itagType != itagTypeWanted) {
+                            return null;
+                        }
+
+                        final ItagInfo itagInfo = buildItagInfo(videoId, formatData, itagItem,
+                                itagItem.itagType, cpn);
+                        if (itagInfo != null && itagItem.itagType == ItagItem.ItagType.AUDIO) {
+                            extractAndSetAudioTrackInfo(formatData, itagInfo, preferredAudioLanguage);
+                        }
+                        return itagInfo;
+                    } catch (final Exception e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull);
+    }
+
+    private void extractAndSetAudioTrackInfo(final JsonObject formatData,
+                                             final ItagInfo itagInfo,
+                                             final String preferredAudioLanguage) {
+        if (!formatData.has("audioTrack")) {
+            return;
+        }
+        final JsonObject audioTrack = formatData.getObject("audioTrack");
+        if (!audioTrack.has("id")) {
+            return;
+        }
+
+        final String audioTrackId = audioTrack.getString("id");
+        final String displayName = audioTrack.getString("displayName", EMPTY_STRING);
+        final String langPart = audioTrackId.split("\\.")[0];
+        final String audioLocale = langPart.split("-")[0];
+        final boolean isDefault = displayName.contains("original")
+                || displayName.contains("yokuqala")
+                || langPart.equals(preferredAudioLanguage);
+        final String audioTrackName = isDefault ? langPart + " (original)" : langPart;
+        itagInfo.setAudioTrackInfo(audioTrackId, audioTrackName, audioLocale);
+    }
+
+    @Nullable
+    private ItagInfo buildItagInfo(@Nonnull final String videoId,
+                                   @Nonnull final JsonObject formatData,
+                                   @Nonnull final ItagItem itagItem,
+                                   @Nonnull final ItagItem.ItagType itagType,
+                                   @Nonnull final String contentPlaybackNonce)
+            throws IOException, ExtractionException {
+        String streamUrl;
+        String obfuscatedSignature = null;
+
+        if (formatData.has("url")) {
+            streamUrl = formatData.getString("url");
+        } else if (formatData.has(SIGNATURE_CIPHER) || formatData.has(CIPHER)) {
+            final String cipherString = formatData.getString(CIPHER,
+                    formatData.getString(SIGNATURE_CIPHER));
+            final Map<String, String> cipher = Parser.compatParseMap(cipherString);
+            obfuscatedSignature = cipher.getOrDefault("s", "");
+            streamUrl = cipher.get("url") + "&" + cipher.get("sp") + "=SIGNATURE_PLACEHOLDER";
+        } else {
+            return null;
+        }
+
+        streamUrl += "&" + CPN + "=" + contentPlaybackNonce;
+
+        final JsonObject initRange = formatData.getObject("initRange");
+        final JsonObject indexRange = formatData.getObject("indexRange");
+        final String mimeType = formatData.getString("mimeType", EMPTY_STRING);
+        final String codec = mimeType.contains("codecs") ? mimeType.split("\"")[1] : EMPTY_STRING;
+        final int fps = formatData.getInt("fps", -1);
+
+        itagItem.setBitrate(formatData.getInt("bitrate"));
+        itagItem.setWidth(formatData.getInt("width"));
+        itagItem.setHeight(formatData.getInt("height"));
+        if (initRange != null) {
+            itagItem.setInitStart(Integer.parseInt(initRange.getString("start", "-1")));
+            itagItem.setInitEnd(Integer.parseInt(initRange.getString("end", "-1")));
+        }
+        if (indexRange != null) {
+            itagItem.setIndexStart(Integer.parseInt(indexRange.getString("start", "-1")));
+            itagItem.setIndexEnd(Integer.parseInt(indexRange.getString("end", "-1")));
+        }
+        itagItem.setQuality(formatData.getString("quality"));
+        itagItem.setCodec(codec);
+
+        if (streamType == StreamType.LIVE_STREAM || streamType == StreamType.POST_LIVE_STREAM) {
+            itagItem.setTargetDurationSec(formatData.getInt("targetDurationSec"));
+        } else if ((itagType == ItagItem.ItagType.VIDEO
+                || itagType == ItagItem.ItagType.VIDEO_ONLY) && fps != -1) {
+            itagItem.setFps(fps);
+        } else if (itagType == ItagItem.ItagType.AUDIO) {
+            if (formatData.has("audioSampleRate")) {
+                itagItem.setSampleRate(Integer.parseInt(formatData.getString("audioSampleRate")));
+            }
+            itagItem.setAudioChannels(formatData.getInt("audioChannels", 2));
+        }
+
+        itagItem.setContentLength(Long.parseLong(formatData.getString("contentLength",
+                String.valueOf(CONTENT_LENGTH_UNKNOWN))));
+        itagItem.setApproxDurationMs(Long.parseLong(formatData.getString("approxDurationMs",
+                String.valueOf(APPROX_DURATION_MS_UNKNOWN))));
+
+        final ItagInfo itagInfo = new ItagInfo(streamUrl, itagItem);
+        itagInfo.setObfuscatedSignature(obfuscatedSignature);
+        itagInfo.setIsUrl(streamType == StreamType.VIDEO_STREAM
+                ? !formatData.getString("type", EMPTY_STRING)
+                        .equalsIgnoreCase("FORMAT_STREAM_TYPE_OTF")
+                : streamType != StreamType.POST_LIVE_STREAM);
+        return itagInfo;
     }
 
 


### PR DESCRIPTION
Refs https://github.com/InfinityLoop1308/PipePipeClient/pull/70#issuecomment-4873271107

## Summary

This fixes the logged-in age-restricted YouTube path I tested after the Android 17 / SABR work.

WEB/MWEB can still return `LOGIN_REQUIRED` without usable `streamingData` even when cookies are present. With a real logged-in / age-verified cookie set, the TV downgraded player can return normal direct streams, but it needs the logged-in watch `ytcfg` state and the correct auth headers.

This adds that fallback and keeps the normal SABR path untouched.

## Problem

The failing path looked like this:

```text
WEB/MWEB player response:
LOGIN_REQUIRED
no streamingData
```

The app then surfaced the normal age-restricted error even though YouTube cookies were configured.

During testing I also found that cookie quality matters a lot here. A partial cookie set still made the app look "logged in" locally, but YouTube returned a signed-out watch page:

```text
no VISITOR_DATA
no SESSION_INDEX
TV player => LOGIN_REQUIRED
```

With a real logged-in cookie set, the watch page exposes:

```text
LOGGED_IN=true
VISITOR_DATA present
SESSION_INDEX=1
```

and the TV downgraded player returns usable direct streams.

## Changes

- Fetch the logged-in YouTube watch `ytcfg` when WEB/MWEB do not provide streams.
- Read `VISITOR_DATA` and `SESSION_INDEX` from the watch page for the TV fallback request.
- Build the TVHTML5 downgraded player request for logged-in fallback.
- Send the full logged-in cookie header and YouTube auth headers.
- Generate all available auth schemes:
  - `SAPISIDHASH`
  - `SAPISID1PHASH`
  - `SAPISID3PHASH`
- Merge the TV fallback `streamingData` into the existing player response instead of replacing all metadata.
- Restore direct stream building for non-SABR `formats` / `adaptiveFormats` returned by the TV fallback.
- Ignore the WEB age-gate error only after the TV fallback actually returned usable streams.

## Validation

Build:

- `./gradlew :extractor:compileJava --no-build-cache --no-configuration-cache --no-daemon`
- `./gradlew :app:assembleDebug --no-build-cache --no-configuration-cache --no-daemon` from PipePipeClient with this extractor through `includeBuild`
- `git diff --check`

Local reverse check with the same cookie set:

```text
ytcfg:
LOGGED_IN=true
VISITOR_DATA present
SESSION_INDEX=1

TV downgraded player:
status=OK
formats=1
adaptiveFormats=6
serverAbrStreamingUrl=false
```

Emulator validation:

Age-restricted playback:

```text
https://www.youtube.com/watch?v=Jrt8nic1UAg
```

Result:

```text
MediaSession PLAYING(3)
title: مشهد مؤثر لاشتباكات المنطقة الثانية سرت
video decoder: h264
audio decoder: aac
```

Age-restricted download:

```text
selected: AVC1 720p
postprocessing completed
```

Final file checked with `ffprobe`:

```text
video: h264 1280x720
audio: aac
duration: 37.685986
size: 10530427
```

Normal playback smoke:

```text
https://www.youtube.com/watch?v=lLaRC7GkVR8
```

Result:

```text
SABR playback reached PLAYING(3)
```

## Notes

This PR is extractor-only.

The client already benefits from this once the extractor returns normal direct streams from the logged-in TV fallback. In my emulator test, playback and download worked with the current client build after substituting this extractor.

This depends on a real logged-in / age-verified YouTube cookie set. A partial cookie set can still contain some YouTube account cookies but fail the age-gate path, and in that case YouTube returns no logged-in watch state and the TV fallback still cannot unlock the video.

I tested that case too while debugging: `yt-dlp` failed with the partial set and passed with the real logged-in set, matching the app behavior.

@InfinityLoop1308 do you want me to look at the client-side login/cookie UX too, or do you prefer to handle that part? (of course if it is needed)
