### PR TITLE
Fix: Blocked channels still visible in search results

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItemsCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/InfoItemsCollector.java
@@ -1,7 +1,9 @@
 package org.schabi.newpipe.extractor;
 
+import org.schabi.newpipe.extractor.channel.ChannelInfoItem;
 import org.schabi.newpipe.extractor.exceptions.FoundAdException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.playlist.PlaylistInfoItem;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 
@@ -175,10 +177,26 @@ public abstract class InfoItemsCollector<I extends InfoItem, E extends InfoItemE
             // Only check channels if we haven't already marked for removal
             if (!shouldRemove) {
                 for (String channel : filterConfig.getChannels()) {
-                    if (item instanceof StreamInfoItem && ((StreamInfoItem) item).getUploaderName() != null &&
-                            ((StreamInfoItem) item).getUploaderName().equals(channel)) {
+                    // Filter videos by uploader name
+                    if (item instanceof StreamInfoItem
+                            && ((StreamInfoItem) item).getUploaderName() != null
+                            && ((StreamInfoItem) item).getUploaderName().equals(channel)) {
                         shouldRemove = true;
-                        break;  // No need to check other channels
+                        break;
+                    }
+                    // Filter channel search results by channel name
+                    if (item instanceof ChannelInfoItem
+                            && item.getName() != null
+                            && item.getName().equals(channel)) {
+                        shouldRemove = true;
+                        break;
+                    }
+                    // Filter playlists by uploader name
+                    if (item instanceof PlaylistInfoItem
+                            && ((PlaylistInfoItem) item).getUploaderName() != null
+                            && ((PlaylistInfoItem) item).getUploaderName().equals(channel)) {
+                        shouldRemove = true;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Bug
When a channel is added to the block list (Settings -> Filter -> Filter by Channel), searching for the channel still shows its icon/card and playlists in search results.

## Root Cause
The `applyBlocking()` method in `InfoItemsCollector` was only checking `StreamInfoItem` (videos) against the blocked channel list. `ChannelInfoItem` (channels) and `PlaylistInfoItem` (playlists) were ignored.

## Fix
Extended the channel filtering check in `applyBlocking()` to also filter out:
- `ChannelInfoItem` (matched by name)
- `PlaylistInfoItem` (matched by uploader name)