### PR TITLE
fix(youtube): restore SABR initialization cold start

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrRequestBuilder.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrRequestBuilder.java
@@ -50,10 +50,13 @@ final class YoutubeSabrRequestBuilder {
         final List<SabrBufferedRange> bufferedRanges = streamState == null
                 ? java.util.Collections.emptyList()
                 : streamState.getBufferedRanges();
-        final boolean includeInitialPlaybackState = playerTimeMs > 0 || !bufferedRanges.isEmpty();
+        final boolean forcedInitialPlaybackState = streamState != null
+                && streamState.shouldWriteFirstRequestPlaybackState();
+        final boolean includeInitialPlaybackState = forcedInitialPlaybackState
+                || playerTimeMs > 0 || !bufferedRanges.isEmpty();
         final SabrProto.Writer request = new SabrProto.Writer();
         request.writeMessage(1, buildClientAbrState(audioFormat, videoFormat, playerTimeMs,
-                includeInitialPlaybackState,
+                includeInitialPlaybackState && !forcedInitialPlaybackState,
                 streamState == null
                         ? ENABLED_TRACK_TYPES_VIDEO_AND_AUDIO
                         : streamState.getEnabledTrackTypesBitfield(),
@@ -270,21 +273,21 @@ final class YoutubeSabrRequestBuilder {
                 return;
             }
             for (final YoutubeSabrFormat format : info.getFormats()) {
-                if (format.isAudio() && streamState.shouldSelectAudioFormat()) {
+                if (format.isAudio() && streamState.shouldPreferAudioFormat()) {
                     request.writeMessage(16, SabrProto.formatId(format));
                 }
             }
             for (final YoutubeSabrFormat format : info.getFormats()) {
-                if (format.isVideo() && streamState.shouldSelectVideoFormat()) {
+                if (format.isVideo() && streamState.shouldPreferVideoFormat()) {
                     request.writeMessage(17, SabrProto.formatId(format));
                 }
             }
             return;
         }
-        if (streamState == null || streamState.shouldSelectAudioFormat()) {
+        if (streamState == null || streamState.shouldPreferAudioFormat()) {
             request.writeMessage(16, SabrProto.formatId(audioFormat));
         }
-        if (streamState == null || streamState.shouldSelectVideoFormat()) {
+        if (streamState == null || streamState.shouldPreferVideoFormat()) {
             request.writeMessage(17, SabrProto.formatId(videoFormat));
         }
     }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
@@ -194,6 +194,23 @@ public final class YoutubeSabrSession {
         if (cachedSegment != null) {
             return cachedSegment;
         }
+        final boolean initializationSegment = request.isInitializationSegment();
+        final YoutubeSabrStreamState.InitializationRequestSnapshot requestSnapshot =
+                initializationSegment
+                        ? streamState.prepareInitializationRequest(request.getFormat()) : null;
+        try {
+            return fetchUncachedSegment(request, localization);
+        } finally {
+            if (requestSnapshot != null) {
+                streamState.restoreInitializationRequest(requestSnapshot);
+            }
+        }
+    }
+
+    @Nonnull
+    private SabrMediaSegment fetchUncachedSegment(@Nonnull final SabrSegmentRequest request,
+                                                   @Nonnull final Localization localization)
+            throws IOException, ExtractionException {
         failIfKnownOutOfBounds(request);
 
         boolean targetPrepared = maybePrepareForDistantMediaSegment(request);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrStreamState.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrStreamState.java
@@ -37,6 +37,9 @@ public final class YoutubeSabrStreamState {
     private volatile int enabledTrackTypesBitfield = YoutubeSabrRequestBuilder.ENABLED_TRACK_TYPES_VIDEO_AND_AUDIO;
     private volatile boolean selectAudioFormat = true;
     private volatile boolean selectVideoFormat = true;
+    private volatile boolean preferAudioFormat = true;
+    private volatile boolean preferVideoFormat = true;
+    private boolean writeFirstRequestPlaybackState;
     private boolean writeTopLevelPlayerTimeMs = true;
     private int clientViewportWidth = -1;
     private int clientViewportHeight = -1;
@@ -219,6 +222,50 @@ public final class YoutubeSabrStreamState {
 
     public void clearPlayerTimeMsOverride() {
         playerTimeMsOverride = -1;
+    }
+
+    @Nonnull
+    synchronized InitializationRequestSnapshot prepareInitializationRequest(
+            @Nonnull final YoutubeSabrFormat format) {
+        final InitializationRequestSnapshot snapshot = new InitializationRequestSnapshot(
+                enabledTrackTypesBitfield,
+                selectAudioFormat,
+                selectVideoFormat,
+                preferAudioFormat,
+                preferVideoFormat,
+                playerTimeMsOverride,
+                bufferedRangesOverride,
+                writeFirstRequestPlaybackState,
+                writeTopLevelPlayerTimeMs,
+                writeLastManualSelectedResolution);
+        final long playerTimeMs = getPlayerTimeMs();
+        writeFirstRequestPlaybackState = true;
+        writeTopLevelPlayerTimeMs = false;
+        writeLastManualSelectedResolution = format.isVideo();
+        bufferedRangesOverride = new ArrayList<>();
+        enabledTrackTypesBitfield = format.isVideo()
+                ? TRACK_MODE_VIDEO_ONLY : TRACK_MODE_AUDIO_ONLY;
+        selectAudioFormat = false;
+        selectVideoFormat = false;
+        preferAudioFormat = true;
+        preferVideoFormat = true;
+        playerTimeMsOverride = Math.max(0, playerTimeMs);
+        return snapshot;
+    }
+
+    synchronized void restoreInitializationRequest(
+            @Nonnull final InitializationRequestSnapshot snapshot) {
+        enabledTrackTypesBitfield = snapshot.enabledTrackTypesBitfield;
+        selectAudioFormat = snapshot.selectAudioFormat;
+        selectVideoFormat = snapshot.selectVideoFormat;
+        preferAudioFormat = snapshot.preferAudioFormat;
+        preferVideoFormat = snapshot.preferVideoFormat;
+        playerTimeMsOverride = snapshot.playerTimeMsOverride;
+        bufferedRangesOverride = snapshot.bufferedRangesOverride == null
+                ? null : new ArrayList<>(snapshot.bufferedRangesOverride);
+        writeFirstRequestPlaybackState = snapshot.writeFirstRequestPlaybackState;
+        writeTopLevelPlayerTimeMs = snapshot.writeTopLevelPlayerTimeMs;
+        writeLastManualSelectedResolution = snapshot.writeLastManualSelectedResolution;
     }
 
     void clearPlaybackCookie() {
@@ -409,6 +456,14 @@ public final class YoutubeSabrStreamState {
         this.enabledTrackTypesBitfield = enabledTrackTypesBitfield;
         this.selectAudioFormat = selectAudioFormat;
         this.selectVideoFormat = selectVideoFormat;
+        this.preferAudioFormat = selectAudioFormat;
+        this.preferVideoFormat = selectVideoFormat;
+    }
+
+    synchronized void setPreferredTrackTypes(final boolean videoActive,
+                                             final boolean audioActive) {
+        preferAudioFormat = audioActive;
+        preferVideoFormat = videoActive;
     }
 
     public void setActiveTrackTypes(final boolean videoActive, final boolean audioActive) {
@@ -493,6 +548,22 @@ public final class YoutubeSabrStreamState {
 
     boolean shouldSelectVideoFormat() {
         return selectVideoFormat;
+    }
+
+    boolean shouldPreferAudioFormat() {
+        return preferAudioFormat;
+    }
+
+    boolean shouldPreferVideoFormat() {
+        return preferVideoFormat;
+    }
+
+    void setWriteFirstRequestPlaybackState(final boolean writeFirstRequestPlaybackState) {
+        this.writeFirstRequestPlaybackState = writeFirstRequestPlaybackState;
+    }
+
+    boolean shouldWriteFirstRequestPlaybackState() {
+        return writeFirstRequestPlaybackState;
     }
 
     public void setWriteTopLevelPlayerTimeMs(final boolean writeTopLevelPlayerTimeMs) {
@@ -998,6 +1069,44 @@ public final class YoutubeSabrStreamState {
 
         private boolean isComplete() {
             return initReceived && endSegment > 0 && maxSegment >= endSegment;
+        }
+    }
+
+    static final class InitializationRequestSnapshot {
+        private final int enabledTrackTypesBitfield;
+        private final boolean selectAudioFormat;
+        private final boolean selectVideoFormat;
+        private final boolean preferAudioFormat;
+        private final boolean preferVideoFormat;
+        private final long playerTimeMsOverride;
+        @Nullable
+        private final List<SabrBufferedRange> bufferedRangesOverride;
+        private final boolean writeFirstRequestPlaybackState;
+        private final boolean writeTopLevelPlayerTimeMs;
+        private final boolean writeLastManualSelectedResolution;
+
+        private InitializationRequestSnapshot(
+                final int enabledTrackTypesBitfield,
+                final boolean selectAudioFormat,
+                final boolean selectVideoFormat,
+                final boolean preferAudioFormat,
+                final boolean preferVideoFormat,
+                final long playerTimeMsOverride,
+                @Nullable final List<SabrBufferedRange> bufferedRangesOverride,
+                final boolean writeFirstRequestPlaybackState,
+                final boolean writeTopLevelPlayerTimeMs,
+                final boolean writeLastManualSelectedResolution) {
+            this.enabledTrackTypesBitfield = enabledTrackTypesBitfield;
+            this.selectAudioFormat = selectAudioFormat;
+            this.selectVideoFormat = selectVideoFormat;
+            this.preferAudioFormat = preferAudioFormat;
+            this.preferVideoFormat = preferVideoFormat;
+            this.playerTimeMsOverride = playerTimeMsOverride;
+            this.bufferedRangesOverride = bufferedRangesOverride == null
+                    ? null : new ArrayList<>(bufferedRangesOverride);
+            this.writeFirstRequestPlaybackState = writeFirstRequestPlaybackState;
+            this.writeTopLevelPlayerTimeMs = writeTopLevelPlayerTimeMs;
+            this.writeLastManualSelectedResolution = writeLastManualSelectedResolution;
         }
     }
 }

--- a/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSessionInitializationStateTest.java
+++ b/extractor/src/test/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSessionInitializationStateTest.java
@@ -1,0 +1,215 @@
+package org.schabi.newpipe.extractor.services.youtube.sabr;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonParser;
+import org.junit.jupiter.api.Test;
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.downloader.CancellableCall;
+import org.schabi.newpipe.extractor.downloader.Downloader;
+import org.schabi.newpipe.extractor.downloader.Request;
+import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.downloader.StreamingResponse;
+import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
+import org.schabi.newpipe.extractor.localization.Localization;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class YoutubeSabrSessionInitializationStateTest {
+    private static final int AUDIO_ITAG = 140;
+    private static final int VIDEO_ITAG = 299;
+    private static final byte[] INITIALIZATION_DATA = {1, 2, 3};
+
+    @Test
+    void successfulInitializationFetchRestoresExactRequestState() throws Exception {
+        final Fixture fixture = createFixture(new FakeDownloader(initializationResponse(AUDIO_ITAG)));
+        final YoutubeSabrStreamState state = fixture.session.getStreamState();
+        state.setFullyBuffered(fixture.audioFormat, true);
+        state.setRequestTrackMode(YoutubeSabrStreamState.TRACK_MODE_AUDIO_ONLY, true, false);
+        state.setPreferredTrackTypes(true, false);
+        state.setPlayerTimeMs(12_345);
+        state.setBufferedRangesOverride(Collections.emptyList());
+        state.setWriteFirstRequestPlaybackState(false);
+        state.setWriteTopLevelPlayerTimeMs(true);
+        state.setWriteLastManualSelectedResolution(true);
+
+        final SabrMediaSegment segment = fixture.session.fetchSegment(
+                SabrSegmentRequest.initialization(fixture.audioFormat), Localization.DEFAULT);
+
+        assertArrayEquals(INITIALIZATION_DATA, segment.getData());
+        assertRequestState(state, 0, false, true, true);
+    }
+
+    @Test
+    void failedInitializationFetchRestoresExactRequestState() throws Exception {
+        final Fixture fixture = createFixture(new FakeDownloader(new IOException("test failure")));
+        final YoutubeSabrStreamState state = fixture.session.getStreamState();
+        state.setFullyBuffered(fixture.audioFormat, true);
+        state.setRequestTrackMode(YoutubeSabrStreamState.TRACK_MODE_AUDIO_ONLY, true, false);
+        state.setPreferredTrackTypes(true, false);
+        state.setPlayerTimeMs(12_345);
+        state.setBufferedRangesOverride(null);
+        state.setWriteFirstRequestPlaybackState(true);
+        state.setWriteTopLevelPlayerTimeMs(false);
+        state.setWriteLastManualSelectedResolution(false);
+
+        assertThrows(IOException.class, () -> fixture.session.fetchSegment(
+                SabrSegmentRequest.initialization(fixture.videoFormat), Localization.DEFAULT));
+
+        assertRequestState(state, 1, true, false, false);
+    }
+
+    private static void assertRequestState(@Nonnull final YoutubeSabrStreamState state,
+                                           final int bufferedRangeCount,
+                                           final boolean writeFirstRequestPlaybackState,
+                                           final boolean writeTopLevelPlayerTimeMs,
+                                           final boolean writeLastManualSelectedResolution) {
+        assertEquals(YoutubeSabrStreamState.TRACK_MODE_AUDIO_ONLY,
+                state.getEnabledTrackTypesBitfield());
+        assertTrue(state.shouldSelectAudioFormat());
+        assertFalse(state.shouldSelectVideoFormat());
+        assertFalse(state.shouldPreferAudioFormat());
+        assertTrue(state.shouldPreferVideoFormat());
+        assertEquals(12_345, state.getPlayerTimeMs());
+        assertEquals(bufferedRangeCount, state.getBufferedRanges().size());
+        assertEquals(writeFirstRequestPlaybackState,
+                state.shouldWriteFirstRequestPlaybackState());
+        assertEquals(writeTopLevelPlayerTimeMs, state.shouldWriteTopLevelPlayerTimeMs());
+        assertEquals(writeLastManualSelectedResolution,
+                state.shouldWriteLastManualSelectedResolution());
+    }
+
+    @Nonnull
+    private static Fixture createFixture(@Nonnull final Downloader downloader) throws Exception {
+        NewPipe.init(downloader);
+        final JsonArray formats = JsonParser.array().from("["
+                + "{\"itag\":140,\"lastModified\":\"1\",\"mimeType\":\"audio/mp4\","
+                + "\"bitrate\":128000,\"contentLength\":\"1000\","
+                + "\"approxDurationMs\":\"60000\"},"
+                + "{\"itag\":299,\"lastModified\":\"2\",\"mimeType\":\"video/mp4\","
+                + "\"width\":1920,\"height\":1080,\"bitrate\":4000000,"
+                + "\"contentLength\":\"2000\",\"approxDurationMs\":\"60000\"}]");
+        final List<YoutubeSabrFormat> parsedFormats =
+                YoutubeSabrFormat.fromAdaptiveFormats("video", formats);
+        final YoutubeSabrFormat audioFormat = parsedFormats.get(0);
+        final YoutubeSabrFormat videoFormat = parsedFormats.get(1);
+        final YoutubeSabrInfo info = new YoutubeSabrInfo(
+                YoutubeSabrClientProfile.MWEB,
+                "video",
+                "cpn",
+                YoutubeSabrClientProfile.MWEB.getClientVersion(),
+                "visitor",
+                "https://example.com/sabr",
+                "AA==",
+                parsedFormats);
+        return new Fixture(
+                new YoutubeSabrSession(info, audioFormat, videoFormat, null, null),
+                audioFormat,
+                videoFormat);
+    }
+
+    @Nonnull
+    private static byte[] initializationResponse(final int itag) {
+        final SabrProto.Writer header = new SabrProto.Writer();
+        header.writeInt32(1, 1);
+        header.writeInt32(3, itag);
+        header.writeBool(8, true);
+        header.writeUInt64(14, INITIALIZATION_DATA.length);
+
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeUmpPart(output, SabrResponseDecoder.MEDIA_HEADER, header.toByteArray());
+        final byte[] media = new byte[INITIALIZATION_DATA.length + 1];
+        media[0] = 1;
+        System.arraycopy(INITIALIZATION_DATA, 0, media, 1, INITIALIZATION_DATA.length);
+        writeUmpPart(output, SabrResponseDecoder.MEDIA, media);
+        writeUmpPart(output, SabrResponseDecoder.MEDIA_END, new byte[]{1});
+        return output.toByteArray();
+    }
+
+    private static void writeUmpPart(@Nonnull final ByteArrayOutputStream output,
+                                     final int type,
+                                     @Nonnull final byte[] payload) {
+        if (type >= 128 || payload.length >= 128) {
+            throw new IllegalArgumentException("Test UMP part exceeds single-byte encoding");
+        }
+        output.write(type);
+        output.write(payload.length);
+        output.write(payload, 0, payload.length);
+    }
+
+    private static final class Fixture {
+        @Nonnull
+        private final YoutubeSabrSession session;
+        @Nonnull
+        private final YoutubeSabrFormat audioFormat;
+        @Nonnull
+        private final YoutubeSabrFormat videoFormat;
+
+        private Fixture(@Nonnull final YoutubeSabrSession session,
+                        @Nonnull final YoutubeSabrFormat audioFormat,
+                        @Nonnull final YoutubeSabrFormat videoFormat) {
+            this.session = session;
+            this.audioFormat = audioFormat;
+            this.videoFormat = videoFormat;
+        }
+    }
+
+    private static final class FakeDownloader extends Downloader {
+        @Nullable
+        private final byte[] responseBody;
+        @Nullable
+        private final IOException failure;
+
+        private FakeDownloader(@Nonnull final byte[] responseBody) {
+            this.responseBody = Arrays.copyOf(responseBody, responseBody.length);
+            this.failure = null;
+        }
+
+        private FakeDownloader(@Nonnull final IOException failure) {
+            this.responseBody = null;
+            this.failure = failure;
+        }
+
+        @Override
+        public StreamingResponse postStreaming(
+                final String url,
+                @Nullable final Map<String, List<String>> headers,
+                @Nullable final byte[] dataToSend,
+                @Nullable final Localization localization) throws IOException {
+            if (failure != null) {
+                throw failure;
+            }
+            return new StreamingResponse(
+                    200,
+                    Collections.singletonMap("Content-Type",
+                            Collections.singletonList("application/vnd.yt-ump")),
+                    new ByteArrayInputStream(responseBody));
+        }
+
+        @Override
+        public Response execute(@Nonnull final Request request)
+                throws IOException, ReCaptchaException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CancellableCall executeAsync(@Nonnull final Request request,
+                                            final AsyncCallback callback)
+                throws IOException, ReCaptchaException {
+            throw new UnsupportedOperationException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

While fixing a SABR playback regression in TypeType, I found that initialization requests could receive several valid SABR responses without the requested init segment.

The session eventually failed with:

```text
Requested SABR segment was not returned: itag=140:init
Requested SABR segment was not returned: itag=299:init
```

PipePipe normally gets initialization data directly from the format metadata, but both the player fallback and the downloader still use `fetchSegment(SabrSegmentRequest.initialization(...))` when that data is unavailable.

This restores the cold-start request shape needed for those initialization requests without changing the normal media request flow.

## Problem

An initialization request needs to identify the requested audio or video track without carrying the buffered ranges and playback state of a normal follow-up request.

With the current request shape, YouTube can return policy and media responses while skipping the requested init segment entirely.

## Changes

- Use an initialization-specific request state while fetching an init segment.
- Enable only the requested audio or video track for that request.
- Keep audio and video format preferences separate from the selected track state.
- Omit buffered ranges and top-level player time from the initialization request.
- Restore the normal session state after the request completes.

## Validation

Build:

- `./gradlew :extractor:compileJava`
- `git diff --check`

Runtime validation through TypeType with the patched extractor:

- audio initialization returned successfully
- video initialization returned successfully
- audio and video media segments continued loading
- playback reached 45 seconds without interruption or player errors

Test videos:

- `https://www.youtube.com/watch?v=X4FeyMPB6SY`
- `https://www.youtube.com/watch?v=J_T7EFHEcpc`

## Notes

This is extractor-only. PipePipe already uses the affected initialization API, so no client change is required.

This does not address WebView, BotGuard, or DNS failures. It only fixes SABR init-segment retrieval.
