### PR TITLE
feat(youtube): support live streams through SABR

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -846,18 +846,17 @@ public class YoutubeStreamExtractor extends StreamExtractor {
         Exception extractionError = primaryPlayerError;
         try {
             final String selectedClient = NewPipe.getYoutubePlayerClient();
-            if (("mweb".equals(selectedClient) || "web".equals(selectedClient))
-                    && streamType != StreamType.LIVE_STREAM
-                    && streamType != StreamType.POST_LIVE_STREAM
-                    && hasSabrStreamingUrl()) {
+            final boolean useSabr = ("mweb".equals(selectedClient)
+                    || "web".equals(selectedClient)) && hasSabrStreamingUrl();
+            if (useSabr) {
                 buildSabrStreams(videoId);
             } else if (!("tv_downgraded".equals(selectedClient)
                     && streamType == StreamType.LIVE_STREAM)) {
                 extractDirectFormats(videoId);
             }
-            if (streamType == StreamType.POST_LIVE_STREAM
+            if (!useSabr && (streamType == StreamType.POST_LIVE_STREAM
                     || (streamType == StreamType.LIVE_STREAM
-                        && "tv_downgraded".equals(selectedClient))) {
+                        && "tv_downgraded".equals(selectedClient)))) {
                 tryExtractHlsStreams(videoId);
             }
         } catch (final Exception e) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaDataNormalizer.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaDataNormalizer.java
@@ -1,0 +1,170 @@
+package org.schabi.newpipe.extractor.services.youtube.sabr;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Locale;
+
+final class SabrMediaDataNormalizer {
+    private static final int MP4_HEADER_SIZE = 8;
+    private static final int MP4_EXTENDED_HEADER_SIZE = 16;
+    private static final long EBML_HEADER_ID = 0x1A45DFA3L;
+    private static final long WEBM_SEGMENT_ID = 0x18538067L;
+    private static final long WEBM_CLUSTER_ID = 0x1F43B675L;
+
+    private SabrMediaDataNormalizer() {
+    }
+
+    @Nullable
+    static SabrMediaDataParts split(@Nullable final String mimeType,
+                                    @Nonnull final byte[] data) {
+        if (mimeType == null) {
+            return null;
+        }
+        final String container = mimeType.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+        if (container.endsWith("/mp4")) {
+            return splitMp4(data);
+        }
+        if (container.endsWith("/webm")) {
+            return splitWebm(data);
+        }
+        return null;
+    }
+
+    @Nullable
+    private static SabrMediaDataParts splitMp4(@Nonnull final byte[] data) {
+        int offset = 0;
+        int initializationEnd = -1;
+        while (offset + MP4_HEADER_SIZE <= data.length) {
+            final long size32 = readUnsignedInt(data, offset);
+            final String type = new String(data, offset + 4, 4, StandardCharsets.US_ASCII);
+            final int headerSize = size32 == 1 ? MP4_EXTENDED_HEADER_SIZE : MP4_HEADER_SIZE;
+            if (offset + headerSize > data.length) {
+                return null;
+            }
+            final long size = size32 == 0 ? data.length - (long) offset
+                    : size32 == 1 ? readUnsignedLong(data, offset + MP4_HEADER_SIZE) : size32;
+            if (size < headerSize || size > data.length - (long) offset) {
+                return null;
+            }
+            final int end = offset + (int) size;
+            if ("moov".equals(type)) {
+                initializationEnd = end;
+            } else if ("moof".equals(type) && initializationEnd > 0) {
+                return splitAt(data, initializationEnd);
+            }
+            offset = end;
+        }
+        return null;
+    }
+
+    @Nullable
+    private static SabrMediaDataParts splitWebm(@Nonnull final byte[] data) {
+        final EbmlElement ebml = readEbmlElement(data, 0);
+        if (ebml == null || ebml.id != EBML_HEADER_ID || ebml.size < 0) {
+            return null;
+        }
+        final long segmentOffset = ebml.payloadOffset + ebml.size;
+        if (segmentOffset > Integer.MAX_VALUE) {
+            return null;
+        }
+        final EbmlElement segment = readEbmlElement(data, (int) segmentOffset);
+        if (segment == null || segment.id != WEBM_SEGMENT_ID) {
+            return null;
+        }
+        int offset = segment.payloadOffset;
+        while (offset < data.length) {
+            final EbmlElement element = readEbmlElement(data, offset);
+            if (element == null) {
+                return null;
+            }
+            if (element.id == WEBM_CLUSTER_ID) {
+                return offset <= segment.payloadOffset ? null : splitAt(data, offset);
+            }
+            if (element.size < 0) {
+                return null;
+            }
+            final long next = element.payloadOffset + element.size;
+            if (next <= offset || next > data.length) {
+                return null;
+            }
+            offset = (int) next;
+        }
+        return null;
+    }
+
+    @Nullable
+    private static EbmlElement readEbmlElement(@Nonnull final byte[] data, final int offset) {
+        final int idLength = vintLength(data, offset, 4);
+        if (idLength < 0) {
+            return null;
+        }
+        final long id = readRawValue(data, offset, idLength);
+        final int sizeOffset = offset + idLength;
+        final int sizeLength = vintLength(data, sizeOffset, 8);
+        if (sizeLength < 0) {
+            return null;
+        }
+        final long rawSize = readRawValue(data, sizeOffset, sizeLength);
+        final long marker = 1L << (7 * sizeLength);
+        final long sizeValue = rawSize & (marker - 1);
+        final long size = sizeValue == marker - 1 ? -1 : sizeValue;
+        return new EbmlElement(id, size, sizeOffset + sizeLength);
+    }
+
+    private static int vintLength(@Nonnull final byte[] data, final int offset,
+                                  final int maximum) {
+        if (offset < 0 || offset >= data.length) {
+            return -1;
+        }
+        final int first = data[offset] & 0xFF;
+        if (first == 0) {
+            return -1;
+        }
+        final int length = Integer.numberOfLeadingZeros(first) - 23;
+        return length >= 1 && length <= maximum && offset + length <= data.length ? length : -1;
+    }
+
+    private static long readUnsignedInt(@Nonnull final byte[] data, final int offset) {
+        return (long) (data[offset] & 0xFF) << 24
+                | (long) (data[offset + 1] & 0xFF) << 16
+                | (long) (data[offset + 2] & 0xFF) << 8
+                | data[offset + 3] & 0xFFL;
+    }
+
+    private static long readUnsignedLong(@Nonnull final byte[] data, final int offset) {
+        final long value = readRawValue(data, offset, 8);
+        return value < 0 ? -1 : value;
+    }
+
+    private static long readRawValue(@Nonnull final byte[] data, final int offset,
+                                     final int length) {
+        if (length < 1 || length > 8 || offset < 0 || offset + length > data.length) {
+            return -1;
+        }
+        long value = 0;
+        for (int i = 0; i < length; i++) {
+            value = (value << 8) | (data[offset + i] & 0xFFL);
+        }
+        return value;
+    }
+
+    @Nonnull
+    private static SabrMediaDataParts splitAt(@Nonnull final byte[] data, final int offset) {
+        return new SabrMediaDataParts(Arrays.copyOfRange(data, 0, offset),
+                Arrays.copyOfRange(data, offset, data.length));
+    }
+
+    private static final class EbmlElement {
+        private final long id;
+        private final long size;
+        private final int payloadOffset;
+
+        private EbmlElement(final long id, final long size, final int payloadOffset) {
+            this.id = id;
+            this.size = size;
+            this.payloadOffset = payloadOffset;
+        }
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaDataParts.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaDataParts.java
@@ -1,0 +1,26 @@
+package org.schabi.newpipe.extractor.services.youtube.sabr;
+
+import javax.annotation.Nonnull;
+
+final class SabrMediaDataParts {
+    @Nonnull
+    private final byte[] initializationData;
+    @Nonnull
+    private final byte[] mediaData;
+
+    SabrMediaDataParts(@Nonnull final byte[] initializationData,
+                       @Nonnull final byte[] mediaData) {
+        this.initializationData = initializationData;
+        this.mediaData = mediaData;
+    }
+
+    @Nonnull
+    byte[] getInitializationData() {
+        return initializationData;
+    }
+
+    @Nonnull
+    byte[] getMediaData() {
+        return mediaData;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaHeader.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaHeader.java
@@ -182,6 +182,26 @@ public final class SabrMediaHeader {
     }
 
     @Nonnull
+    static SabrMediaHeader initializationFrom(@Nonnull final SabrMediaHeader source,
+                                              final int contentLength) {
+        return new SabrMediaHeader(source.headerId, source.videoId, source.itag,
+                source.lastModified, source.xtags, source.startRange,
+                source.compressionAlgorithm, true, -1, source.bitrateBps, 0, 0,
+                contentLength, 0, 0, source.timeRangeTimescale, source.sequenceLastModified);
+    }
+
+    @Nonnull
+    static SabrMediaHeader mediaFrom(@Nonnull final SabrMediaHeader source,
+                                     final int contentLength) {
+        return new SabrMediaHeader(source.headerId, source.videoId, source.itag,
+                source.lastModified, source.xtags, source.startRange,
+                source.compressionAlgorithm, false, source.sequenceNumber, source.bitrateBps,
+                source.startMs, source.durationMs, contentLength, source.timeRangeStartTicks,
+                source.timeRangeDurationTicks, source.timeRangeTimescale,
+                source.sequenceLastModified);
+    }
+
+    @Nonnull
     private static FormatId decodeFormatId(@Nonnull final byte[] data) throws SabrProtocolException {
         int itag = -1;
         long lastModified = -1;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaSegmentCollector.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrMediaSegmentCollector.java
@@ -145,6 +145,10 @@ public final class SabrMediaSegmentCollector {
             return null;
         }
 
+        public boolean hasOpenSegments() {
+            return !openSegments.isEmpty();
+        }
+
         public void abort() {
             for (final OpenSegment segment : openSegments.values()) {
                 segment.abort();

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrStreamingResponseReader.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrStreamingResponseReader.java
@@ -42,6 +42,11 @@ public final class SabrStreamingResponseReader {
         boolean accept(@Nonnull SabrMediaSegment segment) throws SabrProtocolException;
     }
 
+    @FunctionalInterface
+    public interface LiveMetadataConsumer {
+        void accept(@Nonnull SabrLiveMetadata metadata) throws SabrProtocolException;
+    }
+
     /**
      * Streams completed segments directly to {@code segmentConsumer}. When a consumer is supplied,
      * completed segments are not retained by the result, bounding the response reader to one open
@@ -78,7 +83,7 @@ public final class SabrStreamingResponseReader {
                                    @Nullable final SegmentConsumer segmentStartConsumer,
                                    @Nullable final File spoolDirectory)
             throws SabrProtocolException, IOException {
-        return readUntil(in, segmentConsumer, segmentStartConsumer, spoolDirectory,
+        return readUntil(in, segmentConsumer, segmentStartConsumer, null, spoolDirectory,
                 SabrMediaProtocol.builtin());
     }
 
@@ -86,6 +91,29 @@ public final class SabrStreamingResponseReader {
     public static Result readUntil(@Nonnull final InputStream in,
                                    final StoppableSegmentConsumer segmentConsumer,
                                    @Nullable final SegmentConsumer segmentStartConsumer,
+                                   @Nullable final File spoolDirectory,
+                                   @Nonnull final SabrMediaProtocol mediaProtocol)
+            throws SabrProtocolException, IOException {
+        return readUntil(in, segmentConsumer, segmentStartConsumer, null, spoolDirectory,
+                mediaProtocol);
+    }
+
+    @Nonnull
+    public static Result readUntil(@Nonnull final InputStream in,
+                                   final StoppableSegmentConsumer segmentConsumer,
+                                   @Nullable final SegmentConsumer segmentStartConsumer,
+                                   @Nullable final LiveMetadataConsumer liveMetadataConsumer,
+                                   @Nullable final File spoolDirectory)
+            throws SabrProtocolException, IOException {
+        return readUntil(in, segmentConsumer, segmentStartConsumer, liveMetadataConsumer,
+                spoolDirectory, SabrMediaProtocol.builtin());
+    }
+
+    @Nonnull
+    public static Result readUntil(@Nonnull final InputStream in,
+                                   final StoppableSegmentConsumer segmentConsumer,
+                                   @Nullable final SegmentConsumer segmentStartConsumer,
+                                   @Nullable final LiveMetadataConsumer liveMetadataConsumer,
                                    @Nullable final File spoolDirectory,
                                    @Nonnull final SabrMediaProtocol mediaProtocol)
             throws SabrProtocolException, IOException {
@@ -163,6 +191,13 @@ public final class SabrStreamingResponseReader {
                         } else {
                             return segmentConsumer.accept(segment);
                         }
+                    }
+                } else if (type == SabrResponseDecoder.LIVE_METADATA) {
+                    final byte[] payload = readPayloadBytes(payloadStream, size);
+                    controlPayloadBytes[0] += payload.length;
+                    controlParts.add(new UmpPart(type, payload.length, payload));
+                    if (liveMetadataConsumer != null) {
+                        liveMetadataConsumer.accept(SabrLiveMetadata.decode(payload));
                     }
                 } else {
                     final byte[] payload = readPayloadBytes(payloadStream, size);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrStreamingResponseReader.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrStreamingResponseReader.java
@@ -128,6 +128,7 @@ public final class SabrStreamingResponseReader {
         final long[] maxPartBytes = {0};
         final long[] maxMediaPartPayloadBytes = {0};
         final long[] maxSegmentBytes = {0};
+        final boolean[] stopAfterOpenSegments = {false};
         // headerId -> total media bytes seen, so the decoded response passes the same integrity check
         // (getIntegrityIssues -> "missing-media") as the buffered path WITHOUT retaining the bytes.
         final Map<Integer, Long> mediaBytesByHeaderId = new HashMap<>();
@@ -188,8 +189,8 @@ public final class SabrStreamingResponseReader {
                         maxSegmentBytes[0] = Math.max(maxSegmentBytes[0], segment.getLength());
                         if (segmentConsumer == null) {
                             segments.add(segment);
-                        } else {
-                            return segmentConsumer.accept(segment);
+                        } else if (!segmentConsumer.accept(segment)) {
+                            stopAfterOpenSegments[0] = true;
                         }
                     }
                 } else if (type == SabrResponseDecoder.LIVE_METADATA) {
@@ -204,7 +205,7 @@ public final class SabrStreamingResponseReader {
                     controlPayloadBytes[0] += payload.length;
                     controlParts.add(new UmpPart(type, payload.length, payload));
                 }
-                return true;
+                return !stopAfterOpenSegments[0] || collector.hasOpenSegments();
             });
         } finally {
             // Any header left open after EOF, cancellation or failure must wake a growing-file

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrProbe.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrProbe.java
@@ -366,10 +366,29 @@ public final class YoutubeSabrProbe {
             @Nullable final File segmentSpoolDirectory,
             @Nonnull final Localization localization)
             throws IOException, ExtractionException {
+        return probeFirstMediaResponseStreamingUntil(info, audioFormat, videoFormat, streamState,
+                serverAbrStreamingUrlOverride, segmentConsumer, segmentStartConsumer, null,
+                segmentSpoolDirectory, localization);
+    }
+
+    @Nonnull
+    static YoutubeSabrProbeResult probeFirstMediaResponseStreamingUntil(
+            @Nonnull final YoutubeSabrInfo info,
+            @Nonnull final YoutubeSabrFormat audioFormat,
+            @Nonnull final YoutubeSabrFormat videoFormat,
+            @Nullable final YoutubeSabrStreamState streamState,
+            @Nullable final String serverAbrStreamingUrlOverride,
+            @Nonnull final SabrStreamingResponseReader.StoppableSegmentConsumer segmentConsumer,
+            @Nonnull final SabrStreamingResponseReader.SegmentConsumer segmentStartConsumer,
+            @Nullable final SabrStreamingResponseReader.LiveMetadataConsumer liveMetadataConsumer,
+            @Nullable final File segmentSpoolDirectory,
+            @Nonnull final Localization localization)
+            throws IOException, ExtractionException {
         final byte[] requestBody = YoutubeSabrRequestBuilder.buildFirstMediaRequest(
                 info, audioFormat, videoFormat, streamState);
         return postMediaRequest(info, requestBody, 0, serverAbrStreamingUrlOverride,
-                segmentConsumer, segmentStartConsumer, segmentSpoolDirectory, localization);
+                segmentConsumer, segmentStartConsumer, liveMetadataConsumer,
+                segmentSpoolDirectory, localization);
     }
 
     @Nonnull
@@ -477,13 +496,33 @@ public final class YoutubeSabrProbe {
             @Nullable final File segmentSpoolDirectory,
             @Nonnull final Localization localization)
             throws IOException, ExtractionException {
+        return probeFollowUpMediaResponseStreamingUntil(info, audioFormat, videoFormat, streamState,
+                requestNumber, serverAbrStreamingUrlOverride, segmentConsumer,
+                segmentStartConsumer, null, segmentSpoolDirectory, localization);
+    }
+
+    @Nonnull
+    static YoutubeSabrProbeResult probeFollowUpMediaResponseStreamingUntil(
+            @Nonnull final YoutubeSabrInfo info,
+            @Nonnull final YoutubeSabrFormat audioFormat,
+            @Nonnull final YoutubeSabrFormat videoFormat,
+            @Nonnull final YoutubeSabrStreamState streamState,
+            final int requestNumber,
+            @Nullable final String serverAbrStreamingUrlOverride,
+            @Nonnull final SabrStreamingResponseReader.StoppableSegmentConsumer segmentConsumer,
+            @Nonnull final SabrStreamingResponseReader.SegmentConsumer segmentStartConsumer,
+            @Nullable final SabrStreamingResponseReader.LiveMetadataConsumer liveMetadataConsumer,
+            @Nullable final File segmentSpoolDirectory,
+            @Nonnull final Localization localization)
+            throws IOException, ExtractionException {
         if (requestNumber <= 0) {
             throw new SabrProtocolException("Follow-up request number must be positive");
         }
         final byte[] requestBody = YoutubeSabrRequestBuilder.buildFollowUpMediaRequest(
                 info, audioFormat, videoFormat, streamState);
         return postMediaRequest(info, requestBody, requestNumber, serverAbrStreamingUrlOverride,
-                segmentConsumer, segmentStartConsumer, segmentSpoolDirectory, localization);
+                segmentConsumer, segmentStartConsumer, liveMetadataConsumer,
+                segmentSpoolDirectory, localization);
     }
 
     @Nonnull
@@ -547,8 +586,7 @@ public final class YoutubeSabrProbe {
             @Nonnull final Localization localization)
             throws IOException, ExtractionException {
         return postMediaRequest(info, requestBody, requestNumber, serverAbrStreamingUrlOverride,
-                segmentConsumer, segmentStartConsumer, segmentSpoolDirectory, localization,
-                SabrMediaProtocol.builtin());
+                segmentConsumer, segmentStartConsumer, null, segmentSpoolDirectory, localization);
     }
 
     @Nonnull
@@ -559,6 +597,41 @@ public final class YoutubeSabrProbe {
             @Nullable final String serverAbrStreamingUrlOverride,
             @Nullable final SabrStreamingResponseReader.StoppableSegmentConsumer segmentConsumer,
             @Nullable final SabrStreamingResponseReader.SegmentConsumer segmentStartConsumer,
+            @Nullable final File segmentSpoolDirectory,
+            @Nonnull final Localization localization,
+            @Nonnull final SabrMediaProtocol mediaProtocol)
+            throws IOException, ExtractionException {
+        return postMediaRequest(info, requestBody, requestNumber, serverAbrStreamingUrlOverride,
+                segmentConsumer, segmentStartConsumer, null, segmentSpoolDirectory, localization,
+                mediaProtocol);
+    }
+
+    @Nonnull
+    static YoutubeSabrProbeResult postMediaRequest(
+            @Nonnull final YoutubeSabrInfo info,
+            @Nonnull final byte[] requestBody,
+            final int requestNumber,
+            @Nullable final String serverAbrStreamingUrlOverride,
+            @Nullable final SabrStreamingResponseReader.StoppableSegmentConsumer segmentConsumer,
+            @Nullable final SabrStreamingResponseReader.SegmentConsumer segmentStartConsumer,
+            @Nullable final SabrStreamingResponseReader.LiveMetadataConsumer liveMetadataConsumer,
+            @Nullable final File segmentSpoolDirectory,
+            @Nonnull final Localization localization)
+            throws IOException, ExtractionException {
+        return postMediaRequest(info, requestBody, requestNumber, serverAbrStreamingUrlOverride,
+                segmentConsumer, segmentStartConsumer, liveMetadataConsumer, segmentSpoolDirectory,
+                localization, SabrMediaProtocol.builtin());
+    }
+
+    @Nonnull
+    static YoutubeSabrProbeResult postMediaRequest(
+            @Nonnull final YoutubeSabrInfo info,
+            @Nonnull final byte[] requestBody,
+            final int requestNumber,
+            @Nullable final String serverAbrStreamingUrlOverride,
+            @Nullable final SabrStreamingResponseReader.StoppableSegmentConsumer segmentConsumer,
+            @Nullable final SabrStreamingResponseReader.SegmentConsumer segmentStartConsumer,
+            @Nullable final SabrStreamingResponseReader.LiveMetadataConsumer liveMetadataConsumer,
             @Nullable final File segmentSpoolDirectory,
             @Nonnull final Localization localization,
             @Nonnull final SabrMediaProtocol mediaProtocol)
@@ -602,10 +675,11 @@ public final class YoutubeSabrProbe {
             final CountingInputStream body = new CountingInputStream(response.body());
             final SabrStreamingResponseReader.Result streamed =
                     timedConsumer == null && timedStartConsumer == null
-                            ? SabrStreamingResponseReader.readUntil(body, null, null, null,
-                            mediaProtocol)
+                            ? SabrStreamingResponseReader.readUntil(body, null, null,
+                            liveMetadataConsumer, null, mediaProtocol)
                             : SabrStreamingResponseReader.readUntil(body, timedConsumer,
-                                    timedStartConsumer, segmentSpoolDirectory, mediaProtocol);
+                                    timedStartConsumer, liveMetadataConsumer,
+                                    segmentSpoolDirectory, mediaProtocol);
             final long requestElapsedMs = elapsedMs(requestStartNs);
             return new YoutubeSabrProbeResult(info, streamed.getDecodedResponse(),
                     streamed.getSegments(), streamed.getSegmentCount(), response.responseCode(),

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
@@ -552,11 +552,11 @@ public final class YoutubeSabrSession {
 
     /**
      * Like {@link #pumpOnceStreaming(Localization)}, but used by callers that are waiting on a
-     * concrete segment. Keep consuming the whole response: SABR/UMP response boundaries are part of
-     * the protocol state, and closing after the target segment can cut off a following media header
-     * whose body/end is still in the same response. Do not sleep in this call when the server sends
-     * a backoff: preserve the full next-request deadline and let the client wait interruptibly so a
-     * synchronously waiting loader can still react to cancellation and reader replacement.
+     * concrete segment. Stop once the target and every media segment already open in the response
+     * are complete, so a live response cannot hold the pump indefinitely. Do not sleep in this call
+     * when the server sends a backoff: preserve the full next-request deadline and let the client
+     * wait interruptibly so a synchronously waiting loader can still react to cancellation and
+     * reader replacement.
      */
     public int pumpOnceStreamingUntilCached(@Nonnull final Localization localization,
                                             @Nonnull final SabrSegmentRequest target)
@@ -594,7 +594,7 @@ public final class YoutubeSabrSession {
             } else if (!header.isInitSegment()) {
                 returnedSegmentsTruncated[0] = true;
             }
-            return true;
+            return !target.matches(header);
         }, false);
         return new DemandResponseResult(result == null ? returnedSegments.size()
                 : result.getSegmentCount(), targetTrackSegments[0], returnedSegments,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
@@ -381,11 +381,14 @@ public final class YoutubeSabrSession {
                 traceCurrentSegmentElapsedMs = -1;
             }
         };
+        final SabrStreamingResponseReader.LiveMetadataConsumer liveMetadataConsumer = metadata -> {
+            streamState.ingestLiveMetadata(metadata);
+        };
         final YoutubeSabrProbeResult result;
         try {
             result = YoutubeSabrProbe.postMediaRequest(info, requestBody, requestNumber,
-                    serverAbrStreamingUrl, timedConsumer, startedConsumer, segmentSpoolDirectory,
-                    localization, sessionPolicyHost.getMediaProtocol());
+                    serverAbrStreamingUrl, timedConsumer, startedConsumer, liveMetadataConsumer,
+                    segmentSpoolDirectory, localization, sessionPolicyHost.getMediaProtocol());
         } catch (final IOException | ExtractionException e) {
             addDiagnosticEvent("request_failed n=" + requestNumber
                     + " type=" + e.getClass().getSimpleName()
@@ -410,7 +413,9 @@ public final class YoutubeSabrSession {
         totalResponseBytes += result.getResponseBytes();
         recordMemoryStats(result);
         recordTraceResponse(result);
-        updateBandwidthEstimate(result.getResponseBytes(), System.nanoTime() - requestStartNs);
+        if (result.getSegmentCount() > 0) {
+            updateBandwidthEstimate(result.getResponseBytes(), System.nanoTime() - requestStartNs);
+        }
         requestNumber++;
         sessionPolicyHost.commitAppliedState(requestPolicyResult, sessionPolicyState());
         return result;
@@ -943,13 +948,19 @@ public final class YoutubeSabrSession {
         }
     }
 
-    private void ingestAndCacheSegment(@Nonnull final SabrMediaSegment segment) {
-        final String key = cacheKey(segment);
-        if (cacheClosed || !segment.isComplete() || segment.hasFailed()) {
-            inFlightSegments.remove(key, segment);
-            segment.delete();
+    private void ingestAndCacheSegment(@Nonnull final SabrMediaSegment sourceSegment) {
+        final String sourceKey = cacheKey(sourceSegment);
+        if (cacheClosed || !sourceSegment.isComplete() || sourceSegment.hasFailed()) {
+            inFlightSegments.remove(sourceKey, sourceSegment);
+            sourceSegment.delete();
             return;
         }
+        final SabrMediaSegment segment = normalizeMediaSegment(sourceSegment);
+        inFlightSegments.remove(sourceKey, sourceSegment);
+        if (segment == null) {
+            return;
+        }
+        final String key = cacheKey(segment);
         streamState.ingest(segment);
         inFlightSegments.remove(key, segment);
         final SabrMediaSegment previous = segmentCache.putIfAbsent(key, segment);
@@ -980,8 +991,53 @@ public final class YoutubeSabrSession {
         evictCacheIfNeeded();
     }
 
+    @Nullable
+    private SabrMediaSegment normalizeMediaSegment(@Nonnull final SabrMediaSegment segment) {
+        final SabrMediaHeader header = segment.getHeader();
+        if (header.isInitSegment()) {
+            return segment;
+        }
+        if (!streamState.isLive()) {
+            return segment;
+        }
+        final YoutubeSabrFormat format = formatForItag(header.getItag());
+        if (format == null) {
+            return segment;
+        }
+        final SabrMediaDataParts parts = SabrMediaDataNormalizer.split(
+                format.getMimeType(), segment.getData());
+        if (parts == null) {
+            return segment;
+        }
+        if (!streamState.isInitialized(format)) {
+            final byte[] initializationData = parts.getInitializationData();
+            ingestAndCacheSegment(new SabrMediaSegment(
+                    SabrMediaHeader.initializationFrom(header, initializationData.length),
+                    initializationData));
+        }
+        segment.delete();
+        final byte[] mediaData = parts.getMediaData();
+        return new SabrMediaSegment(
+                SabrMediaHeader.mediaFrom(header, mediaData.length), mediaData);
+    }
+
+    @Nullable
+    private YoutubeSabrFormat formatForItag(final int itag) {
+        if (audioFormat.getItag() == itag) {
+            return audioFormat;
+        }
+        return videoFormat.getItag() == itag ? videoFormat : null;
+    }
+
     private void publishInFlightSegment(@Nonnull final SabrMediaSegment segment) {
         if (segment.isComplete() || segment.getHeader().isInitSegment()) {
+            return;
+        }
+        if (streamState.isLive()) {
+            return;
+        }
+        final YoutubeSabrFormat format = formatForItag(segment.getHeader().getItag());
+        if (format != null && !streamState.isInitialized(format)) {
             return;
         }
         if (cacheClosed) {
@@ -1422,7 +1478,7 @@ public final class YoutubeSabrSession {
 
     /** True once the requested media segment is known to be past the last segment of the stream. */
     public boolean isBeyondEnd(@Nonnull final SabrSegmentRequest request) {
-        if (request.isInitializationSegment()) {
+        if (request.isInitializationSegment() || streamState.isActiveLive()) {
             return false;
         }
         final long endSegment = streamState.getEndSegment(request.getFormat());
@@ -1433,14 +1489,29 @@ public final class YoutubeSabrSession {
         return streamState.isComplete();
     }
 
-    /** True once the server has reported this is a live stream (foundation for live support). */
     public boolean isLive() {
         return streamState.isLive();
     }
 
-    /** Latest segment the live edge has reached, or -1 if unknown / not live. */
+    public boolean isActiveLive() {
+        return streamState.isActiveLive();
+    }
+
+    /** Absolute broadcast head reported by live metadata, or -1 if unknown / not live. */
     public long getLiveHeadSequenceNumber() {
         return streamState.getLiveHeadSequenceNumber();
+    }
+
+    public long getLiveHeadTimeMs() {
+        return streamState.getLiveHeadTimeMs();
+    }
+
+    public long getLiveSeekableStartTimeMs() {
+        return streamState.getLiveSeekableStartTimeMs();
+    }
+
+    public long getLiveSeekableEndTimeMs() {
+        return streamState.getLiveSeekableEndTimeMs();
     }
 
     /**
@@ -1703,7 +1774,7 @@ public final class YoutubeSabrSession {
 
     private void failIfKnownOutOfBounds(@Nonnull final SabrSegmentRequest request)
             throws SabrProtocolException {
-        if (request.isInitializationSegment()) {
+        if (request.isInitializationSegment() || streamState.isActiveLive()) {
             return;
         }
         final long endSegment = streamState.getEndSegment(request.getFormat());
@@ -1719,7 +1790,7 @@ public final class YoutubeSabrSession {
             return false;
         }
         final YoutubeSabrFormat format = request.getFormat();
-        if (streamState.getEndSegment(format) <= 0) {
+        if (streamState.isActiveLive() || streamState.getEndSegment(format) <= 0) {
             return false;
         }
         if (request.getSequenceNumber() <= streamState.getMaxSegment(format) + 1) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrStreamState.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrStreamState.java
@@ -28,7 +28,7 @@ public final class YoutubeSabrStreamState {
     private byte[] poToken;
     @Nullable
     private volatile SabrNextRequestPolicy nextRequestPolicy;
-    private long playerTimeMsOverride = -1;
+    private volatile long playerTimeMsOverride = -1;
     private boolean audioFullyBuffered;
     private boolean videoFullyBuffered;
     private boolean audioLastOnlyRange;
@@ -73,14 +73,13 @@ public final class YoutubeSabrStreamState {
     @Nullable
     private List<SabrBufferedRange> bufferedRangesOverride;
 
-    // how close to the head counts as "at the live edge" (segments of slack before we wait)
     private static final long LIVE_EDGE_MARGIN_SEGMENTS = 2;
-    // live: foundation only. we record what the server tells us about the live edge (via
-    // LIVE_METADATA) so a future live-aware pump can follow the head. VOD never sets these.
-    private boolean live;
-    private boolean postLiveDvr;
-    private long liveHeadSequenceNumber = -1;
-    private long liveHeadTimeMs = -1;
+    private volatile boolean live;
+    private volatile boolean postLiveDvr;
+    private volatile long liveHeadSequenceNumber = -1;
+    private volatile long liveHeadTimeMs = -1;
+    private volatile long liveSeekableStartTimeMs = -1;
+    private volatile long liveSeekableEndTimeMs = -1;
 
     public YoutubeSabrStreamState(@Nonnull final YoutubeSabrFormat audioFormat,
                                   @Nonnull final YoutubeSabrFormat videoFormat) {
@@ -113,14 +112,7 @@ public final class YoutubeSabrStreamState {
     boolean ingestLocalProgress(@Nonnull final SabrResponseStatePatch patch) {
         boolean progressed = false;
         for (final SabrLiveMetadata meta : patch.getLiveMetadata()) {
-            live = true;
-            postLiveDvr = meta.isPostLiveDvr();
-            if (meta.getHeadSequenceNumber() >= 0) {
-                liveHeadSequenceNumber = meta.getHeadSequenceNumber();
-            }
-            if (meta.getHeadTimeMs() >= 0) {
-                liveHeadTimeMs = meta.getHeadTimeMs();
-            }
+            progressed |= ingestLiveMetadata(meta);
         }
         for (final SabrFormatInitializationMetadata metadata
                 : patch.getFormatMetadata()) {
@@ -136,6 +128,47 @@ public final class YoutubeSabrStreamState {
             }
         }
         return progressed;
+    }
+
+    boolean ingestLiveMetadata(@Nonnull final SabrLiveMetadata metadata) {
+        final boolean wasLive = live;
+        final boolean wasPostLiveDvr = postLiveDvr;
+        final long previousHeadSequenceNumber = liveHeadSequenceNumber;
+        final long previousHeadTimeMs = liveHeadTimeMs;
+        final long previousSeekableStartTimeMs = liveSeekableStartTimeMs;
+        final long previousSeekableEndTimeMs = liveSeekableEndTimeMs;
+        live = true;
+        postLiveDvr |= metadata.isPostLiveDvr();
+        liveHeadSequenceNumber = advance(liveHeadSequenceNumber,
+                metadata.getHeadSequenceNumber());
+        liveHeadTimeMs = advance(liveHeadTimeMs, metadata.getHeadTimeMs());
+        liveSeekableStartTimeMs = advance(liveSeekableStartTimeMs,
+                scaleToMilliseconds(metadata.getMinSeekableTimeTicks(),
+                        metadata.getMinSeekableTimescale()));
+        liveSeekableEndTimeMs = advance(liveSeekableEndTimeMs,
+                scaleToMilliseconds(metadata.getMaxSeekableTimeTicks(),
+                        metadata.getMaxSeekableTimescale()));
+        return wasLive != live
+                || wasPostLiveDvr != postLiveDvr
+                || previousHeadSequenceNumber != liveHeadSequenceNumber
+                || previousHeadTimeMs != liveHeadTimeMs
+                || previousSeekableStartTimeMs != liveSeekableStartTimeMs
+                || previousSeekableEndTimeMs != liveSeekableEndTimeMs;
+    }
+
+    private static long advance(final long current, final long candidate) {
+        return candidate < 0 ? current : Math.max(current, candidate);
+    }
+
+    private static long scaleToMilliseconds(final long ticks, final int timescale) {
+        if (ticks < 0 || timescale <= 0) {
+            return -1;
+        }
+        final long seconds = ticks / timescale;
+        if (seconds > Long.MAX_VALUE / 1000L) {
+            return Long.MAX_VALUE;
+        }
+        return seconds * 1000L + ticks % timescale * 1000L / timescale;
     }
 
     public boolean ingest(@Nonnull final SabrMediaSegment segment) {
@@ -191,6 +224,9 @@ public final class YoutubeSabrStreamState {
     public long getPlayerTimeMs() {
         if (playerTimeMsOverride >= 0) {
             return playerTimeMsOverride;
+        }
+        if (isActiveLive()) {
+            return 0;
         }
         return Math.max(audio.getBufferedEndMs(), video.getBufferedEndMs());
     }
@@ -340,13 +376,17 @@ public final class YoutubeSabrStreamState {
     }
 
     public boolean isComplete() {
-        return (!isAudioEnabled() || audio.isComplete())
+        return !isActiveLive()
+                && (!isAudioEnabled() || audio.isComplete())
                 && (!isVideoEnabled() || video.isComplete());
     }
 
-    /** True once the server has sent live metadata for this stream (foundation for live support). */
     public boolean isLive() {
         return live;
+    }
+
+    public boolean isActiveLive() {
+        return live && !postLiveDvr;
     }
 
     /** True for an ended live stream still seekable as DVR. */
@@ -354,7 +394,7 @@ public final class YoutubeSabrStreamState {
         return postLiveDvr;
     }
 
-    /** Latest segment the live edge has reached, or -1 if unknown / not live. */
+    /** Absolute broadcast head reported by live metadata, or -1 if unknown / not live. */
     public long getLiveHeadSequenceNumber() {
         return liveHeadSequenceNumber;
     }
@@ -364,6 +404,14 @@ public final class YoutubeSabrStreamState {
         return liveHeadTimeMs;
     }
 
+    public long getLiveSeekableStartTimeMs() {
+        return liveSeekableStartTimeMs;
+    }
+
+    public long getLiveSeekableEndTimeMs() {
+        return liveSeekableEndTimeMs;
+    }
+
     /**
      * True when we have fetched up to (within a small margin of) the live head: the slower track has
      * reached the edge, so a live-aware pump should wait for the head to advance instead of treating
@@ -371,7 +419,7 @@ public final class YoutubeSabrStreamState {
      */
     public boolean isAtLiveEdge(@Nonnull final YoutubeSabrFormat audioFormat,
                                 @Nonnull final YoutubeSabrFormat videoFormat) {
-        if (!live || liveHeadSequenceNumber < 0) {
+        if (!isActiveLive() || liveHeadSequenceNumber < 0) {
             return false;
         }
         final long slowerTrack = Math.min(getMaxSegment(audioFormat), getMaxSegment(videoFormat));
@@ -392,7 +440,7 @@ public final class YoutubeSabrStreamState {
     }
 
     public boolean isComplete(@Nonnull final YoutubeSabrFormat format) {
-        return progressForItag(format.getItag()).isComplete();
+        return !isActiveLive() && progressForItag(format.getItag()).isComplete();
     }
 
     public void assumeBufferedUntil(@Nonnull final YoutubeSabrFormat format,
@@ -836,10 +884,15 @@ public final class YoutubeSabrStreamState {
         }
 
         private boolean observeSegment(@Nonnull final SabrMediaSegment segment) {
-            if (!segment.getHeader().isInitSegment() || metadata == null || segmentIndex != null) {
-                return false;
+            if (!segment.getHeader().isInitSegment()) {
+                return observeHeader(segment.getHeader());
             }
-            return observeInitializationData(segment.getData());
+            final boolean changed = !initReceived;
+            initReceived = true;
+            if (segmentIndex != null) {
+                return changed;
+            }
+            return observeInitializationData(segment.getData()) || changed;
         }
 
         private boolean observeInitializationData(@Nonnull final byte[] data) {


### PR DESCRIPTION
Depends on https://github.com/InfinityLoop1308/PipePipeExtractor/pull/86

Part of https://github.com/TypeType-Video/TypeType/issues/145

## Summary

While working on live SABR support in TypeType, I found that PipePipeExtractor already decodes most of the required live protocol data, but live streams are still excluded from the normal SABR stream and session path.

YouTube live responses also behave differently from VOD responses: the live window evolves through `LIVE_METADATA`, segment numbers are absolute within the broadcast timeline, and MP4/WebM media responses can include initialization data again with each media fragment.

This adds the missing extractor-side handling for those cases.

## Problem

The current stream extractor only builds WEB/MWEB SABR streams for VOD. Live and post-live streams are routed through the existing HLS path instead.

Even when a SABR session is opened manually, the session still has several VOD assumptions:

- live metadata is only applied after the streaming response has already been consumed
- reaching the current live head can be interpreted as the end of the stream
- absolute live segment sequences can be treated like a finite VOD timeline
- self-initializing live fragments are exposed as regular media segments even though callers expect initialization and media data separately

This prevents a downstream client from driving a complete live SABR session through the normal extractor API.

## Changes

- Allow WEB/MWEB SABR stream extraction for live and post-live streams.
- Process `LIVE_METADATA` while the UMP response is still being streamed.
- Track the absolute live head sequence, head time and seekable window.
- Distinguish an active live stream from a post-live DVR stream.
- Keep an active live session open when it reaches the current live head.
- Preserve absolute live segment sequence numbers.
- Split self-initializing MP4 live fragments into `ftyp` / `moov` initialization data and `moof` / `mdat` media data.
- Split self-initializing WebM fragments before the first `Cluster`.
- Cache synthesized initialization segments through the existing SABR session API.
- Keep every audio and video format advertised by YouTube available, including H.264, VP9 and AV1.
- Skip the HLS extraction path when a usable SABR response is available.

## Validation

Build:

- `./gradlew :extractor:compileJava`
- `./gradlew :extractor:build`
- `git diff --check`

Live SABR probe:

```text
video: Lt1KH3D_Pe8

H.264: itag 298
VP9: itag 302
AV1: itag 398
audio: itag 140
```

Observed behavior:

- live metadata arrived before the media segments
- the live head and seekable window advanced correctly
- follow-up requests used absolute broadcast segment sequences
- MP4 and WebM initialization data were separated from media data
- all three tested video codecs and the audio format returned usable segments

## Notes

This PR is extractor-only.

It does not switch PipePipe Client live playback from its current DASH/HLS path to SABR. It makes the existing extractor SABR API capable of supporting live playback when a client chooses to use it.
