### PR TITLE
fix(youtube): refresh rejected SABR player contexts

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -68,7 +68,6 @@ import java.util.stream.Stream;
 import static java.util.Collections.singletonList;
 import static org.schabi.newpipe.extractor.NewPipe.getDownloader;
 import static org.schabi.newpipe.extractor.services.youtube.ClientsConstants.*;
-import static org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor.checkPlayabilityStatus;
 import static org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeStreamExtractor.isPlayerResponseNotValid;
 import static org.schabi.newpipe.extractor.utils.Utils.HTTP;
 import static org.schabi.newpipe.extractor.utils.Utils.HTTPS;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlayerResponseValidator.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubePlayerResponseValidator.java
@@ -1,0 +1,142 @@
+package org.schabi.newpipe.extractor.services.youtube;
+
+import com.grack.nanojson.JsonArray;
+import com.grack.nanojson.JsonObject;
+
+import org.schabi.newpipe.extractor.exceptions.AgeRestrictedContentException;
+import org.schabi.newpipe.extractor.exceptions.AntiBotException;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
+import org.schabi.newpipe.extractor.exceptions.GeographicRestrictionException;
+import org.schabi.newpipe.extractor.exceptions.LiveNotStartException;
+import org.schabi.newpipe.extractor.exceptions.PaidContentException;
+import org.schabi.newpipe.extractor.exceptions.ParsingException;
+import org.schabi.newpipe.extractor.exceptions.PrivateContentException;
+import org.schabi.newpipe.extractor.exceptions.VideoNotReleaseException;
+import org.schabi.newpipe.extractor.exceptions.YoutubeMusicPremiumContentException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Maps Innertube player playability statuses to extractor exceptions.
+ */
+public final class YoutubePlayerResponseValidator {
+    private static final String BOT_VERIFICATION_HELP_PATH =
+            "support.google.com/youtube/answer/3037019";
+
+    private YoutubePlayerResponseValidator() {
+    }
+
+    /**
+     * Validates a player response's {@code playabilityStatus} object.
+     *
+     * @param playabilityStatus the player response status object
+     * @throws ParsingException when YouTube rejects or cannot play the content
+     */
+    public static void checkPlayabilityStatus(@Nonnull final JsonObject playabilityStatus)
+            throws ParsingException {
+        final String status = playabilityStatus.getString("status");
+        if (status == null || status.equalsIgnoreCase("ok")) {
+            return;
+        }
+
+        final String reason = playabilityStatus.getString("reason");
+        if (status.equalsIgnoreCase("login_required")) {
+            if (reason == null) {
+                final JsonArray messages = playabilityStatus.getArray("messages");
+                final String message = messages == null || messages.isEmpty()
+                        ? null : messages.getString(0);
+                if (message != null && message.contains("private")) {
+                    throw new PrivateContentException("This video is private");
+                }
+            } else if (reason.contains("age")) {
+                throw new AgeRestrictedContentException(
+                        "This age-restricted video cannot be watched anonymously");
+            }
+        }
+
+        if ((status.equalsIgnoreCase("unplayable") || status.equalsIgnoreCase("error"))
+                && reason != null) {
+            if (reason.contains("Music Premium")) {
+                throw new YoutubeMusicPremiumContentException();
+            }
+            if (reason.contains("payment")) {
+                throw new PaidContentException("This video is a paid video");
+            }
+            if (reason.contains("members-only")) {
+                throw new PaidContentException("This video is only available"
+                        + " for members of the channel of this video");
+            }
+            if (reason.contains("unavailable")) {
+                final JsonObject renderer = getPlayerErrorMessageRenderer(playabilityStatus);
+                final String detailedErrorMessage = renderer == null ? null
+                        : YoutubeParsingHelper.getTextFromObject(renderer.getObject("subreason"));
+                if (detailedErrorMessage != null && detailedErrorMessage.contains("country")) {
+                    throw new GeographicRestrictionException(
+                            "This video is not available in client's country.");
+                }
+                throw new ContentNotAvailableException(detailedErrorMessage == null
+                        ? reason : detailedErrorMessage);
+            }
+        }
+        if (isBotVerificationRequired(playabilityStatus, reason)) {
+            throw new AntiBotException(reason == null
+                    ? "YouTube bot verification is required" : reason);
+        }
+        if (reason != null && reason.contains("This live event will begin in")) {
+            throw new LiveNotStartException(reason);
+        }
+        if (reason != null && reason.contains("Premieres in")) {
+            throw new VideoNotReleaseException(reason);
+        }
+        throw new ContentNotAvailableException("Got error: \"" + reason + "\"");
+    }
+
+    private static boolean isBotVerificationRequired(
+            @Nonnull final JsonObject playabilityStatus,
+            @Nullable final String reason) {
+        if (reason != null && reason.contains("Sign in to confirm")) {
+            return true;
+        }
+        final JsonObject renderer = getPlayerErrorMessageRenderer(playabilityStatus);
+        final JsonObject subreason = renderer == null ? null : renderer.getObject("subreason");
+        final JsonArray runs = subreason == null ? null : subreason.getArray("runs");
+        if (runs == null) {
+            return false;
+        }
+        for (final Object value : runs) {
+            if (value instanceof JsonObject && hasBotVerificationHelpUrl((JsonObject) value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasBotVerificationHelpUrl(@Nonnull final JsonObject run) {
+        final JsonObject navigationEndpoint = run.getObject("navigationEndpoint");
+        if (navigationEndpoint == null) {
+            return false;
+        }
+        final JsonObject urlEndpoint = navigationEndpoint.getObject("urlEndpoint");
+        if (hasBotVerificationHelpPath(urlEndpoint == null
+                ? null : urlEndpoint.getString("url"))) {
+            return true;
+        }
+        final JsonObject commandMetadata = navigationEndpoint.getObject("commandMetadata");
+        final JsonObject webCommandMetadata = commandMetadata == null ? null
+                : commandMetadata.getObject("webCommandMetadata");
+        return hasBotVerificationHelpPath(webCommandMetadata == null
+                ? null : webCommandMetadata.getString("url"));
+    }
+
+    private static boolean hasBotVerificationHelpPath(@Nullable final String url) {
+        return url != null && url.contains(BOT_VERIFICATION_HELP_PATH);
+    }
+
+    @Nullable
+    private static JsonObject getPlayerErrorMessageRenderer(
+            @Nonnull final JsonObject playabilityStatus) {
+        final JsonObject errorScreen = playabilityStatus.getObject("errorScreen");
+        return errorScreen == null ? null : errorScreen.getObject("playerErrorMessageRenderer");
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeStreamExtractor.java
@@ -1860,71 +1860,11 @@ public class YoutubeStreamExtractor extends StreamExtractor {
 
 
 
-    public static JsonObject checkPlayabilityStatus(@Nonnull JsonObject playabilityStatus, String videoId)
+    public static JsonObject checkPlayabilityStatus(@Nonnull final JsonObject playabilityStatus,
+                                                    final String videoId)
             throws ParsingException {
-        String status = playabilityStatus.getString("status");
-        if (status == null || status.equalsIgnoreCase("ok")) {
-            return null;
-        }
-
-        final String reason = playabilityStatus.getString("reason");
-
-        if (status.equalsIgnoreCase("login_required")) {
-            if (reason == null) {
-                final String message = playabilityStatus.getArray("messages").getString(0);
-                if (message != null && message.contains("private")) {
-                    throw new PrivateContentException("This video is private");
-                }
-            } else if (reason.contains("age")) {
-                throw new AgeRestrictedContentException(
-                        "This age-restricted video cannot be watched anonymously");
-            }
-        }
-
-        if ((status.equalsIgnoreCase("unplayable") || status.equalsIgnoreCase("error"))
-                && reason != null) {
-            if (reason.contains("Music Premium")) {
-                throw new YoutubeMusicPremiumContentException();
-            }
-
-            if (reason.contains("payment")) {
-                throw new PaidContentException("This video is a paid video");
-            }
-
-            if (reason.contains("members-only")) {
-                throw new PaidContentException("This video is only available"
-                        + " for members of the channel of this video");
-            }
-
-            if (reason.contains("unavailable")) {
-                final String detailedErrorMessage = getTextFromObject(playabilityStatus
-                        .getObject("errorScreen")
-                        .getObject("playerErrorMessageRenderer")
-                        .getObject("subreason"));
-                if (detailedErrorMessage != null && detailedErrorMessage.contains("country")) {
-                    throw new GeographicRestrictionException(
-                            "This video is not available in client's country.");
-                } else {
-                    if(detailedErrorMessage != null) {
-                        throw new ContentNotAvailableException(detailedErrorMessage);
-                    }
-                    throw new ContentNotAvailableException(reason);
-                }
-            }
-        }
-        if (reason != null && reason.contains("Sign in to confirm")) {
-            throw new AntiBotException(reason);
-        }
-
-        if (reason != null && reason.contains("This live event will begin in")) {
-            throw new LiveNotStartException(reason);
-        }
-
-        if (reason != null && reason.contains("Premieres in")) {
-            throw new VideoNotReleaseException(reason);
-        }
-
-        throw new ContentNotAvailableException("Got error: \"" + reason + "\"");
+        YoutubePlayerResponseValidator.checkPlayabilityStatus(playabilityStatus);
+        return null;
     }
 
     private CancellableCall fetchWebJsonPlayer(@Nonnull final ContentCountry contentCountry,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrPoTokenProvider.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/SabrPoTokenProvider.java
@@ -7,12 +7,14 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 /**
- * Supplies raw WEB PO token bytes for experimental SABR requests.
+ * Supplies raw video ID-bound PO token bytes for SABR media requests.
+ * This token belongs in {@code StreamerContext}; it must not be used as the
+ * visitor/session-bound PO token on the Innertube player request.
  */
 @FunctionalInterface
 public interface SabrPoTokenProvider {
     /**
-     * Returns raw PO token bytes for the current SABR session, or {@code null} if unavailable.
+     * Returns raw content PO token bytes for the current video, or {@code null} if unavailable.
      */
     @Nullable
     byte[] getPoToken(@Nonnull YoutubeSabrInfo info,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubePlayerAdmissionException.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubePlayerAdmissionException.java
@@ -1,0 +1,65 @@
+package org.schabi.newpipe.extractor.services.youtube.sabr;
+
+import org.schabi.newpipe.extractor.exceptions.AntiBotException;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Indicates that YouTube rejected a WEB or MWEB player request before exposing SABR metadata.
+ */
+public final class YoutubePlayerAdmissionException extends AntiBotException {
+    @Nonnull
+    private final String videoId;
+    @Nonnull
+    private final YoutubeSabrClientProfile profile;
+    @Nonnull
+    private final String playabilityStatus;
+    private final boolean playerPoTokenSupplied;
+    private final boolean visitorDataSupplied;
+    private final boolean playerContextRefreshed;
+
+    YoutubePlayerAdmissionException(@Nonnull final String videoId,
+                                    @Nonnull final YoutubeSabrClientProfile profile,
+                                    @Nonnull final String playabilityStatus,
+                                    @Nonnull final String reason,
+                                    final boolean playerPoTokenSupplied,
+                                    final boolean visitorDataSupplied,
+                                    final boolean playerContextRefreshed,
+                                    @Nonnull final AntiBotException cause) {
+        super("YouTube rejected " + profile.getClientName() + " player admission: " + reason,
+                cause);
+        this.videoId = videoId;
+        this.profile = profile;
+        this.playabilityStatus = playabilityStatus;
+        this.playerPoTokenSupplied = playerPoTokenSupplied;
+        this.visitorDataSupplied = visitorDataSupplied;
+        this.playerContextRefreshed = playerContextRefreshed;
+    }
+
+    @Nonnull
+    public String getVideoId() {
+        return videoId;
+    }
+
+    @Nonnull
+    public YoutubeSabrClientProfile getProfile() {
+        return profile;
+    }
+
+    @Nonnull
+    public String getPlayabilityStatus() {
+        return playabilityStatus;
+    }
+
+    public boolean isPlayerPoTokenSupplied() {
+        return playerPoTokenSupplied;
+    }
+
+    public boolean isVisitorDataSupplied() {
+        return visitorDataSupplied;
+    }
+
+    public boolean wasPlayerContextRefreshed() {
+        return playerContextRefreshed;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrInfo.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrInfo.java
@@ -25,6 +25,10 @@ public final class YoutubeSabrInfo implements Serializable {
     private final String videoPlaybackUstreamerConfig;
     @Nonnull
     private final List<YoutubeSabrFormat> formats;
+    @Nullable
+    private final transient YoutubeSabrPlayerContextProvider playerContextProvider;
+    @Nullable
+    private final transient String playerPoToken;
 
     YoutubeSabrInfo(@Nonnull final YoutubeSabrClientProfile profile,
                     @Nonnull final String videoId,
@@ -33,7 +37,9 @@ public final class YoutubeSabrInfo implements Serializable {
                     @Nullable final String visitorData,
                     @Nullable final String serverAbrStreamingUrl,
                     @Nullable final String videoPlaybackUstreamerConfig,
-                    @Nonnull final List<YoutubeSabrFormat> formats) {
+                    @Nonnull final List<YoutubeSabrFormat> formats,
+                    @Nullable final YoutubeSabrPlayerContextProvider playerContextProvider,
+                    @Nullable final String playerPoToken) {
         this.profile = profile;
         this.videoId = videoId;
         this.cpn = cpn;
@@ -42,6 +48,8 @@ public final class YoutubeSabrInfo implements Serializable {
         this.serverAbrStreamingUrl = serverAbrStreamingUrl;
         this.videoPlaybackUstreamerConfig = videoPlaybackUstreamerConfig;
         this.formats = formats;
+        this.playerContextProvider = playerContextProvider;
+        this.playerPoToken = playerPoToken;
     }
 
     @Nonnull
@@ -82,6 +90,16 @@ public final class YoutubeSabrInfo implements Serializable {
     @Nonnull
     public List<YoutubeSabrFormat> getFormats() {
         return Collections.unmodifiableList(formats);
+    }
+
+    @Nullable
+    YoutubeSabrPlayerContextProvider getPlayerContextProvider() {
+        return playerContextProvider;
+    }
+
+    @Nullable
+    String getPlayerPoToken() {
+        return playerPoToken;
     }
 
     @Nullable

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrPlayerContext.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrPlayerContext.java
@@ -1,0 +1,38 @@
+package org.schabi.newpipe.extractor.services.youtube.sabr;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Route-affine material used together for an Innertube player request.
+ * The PO token is bound to the visitor ID for an anonymous session, or to the
+ * account data sync ID when the provider uses an authenticated session.
+ */
+public final class YoutubeSabrPlayerContext {
+    @Nonnull
+    private final String visitorData;
+    @Nonnull
+    private final String playerPoToken;
+
+    public YoutubeSabrPlayerContext(@Nonnull final String visitorData,
+                                    @Nonnull final String playerPoToken) {
+        this.visitorData = Objects.requireNonNull(visitorData, "visitorData");
+        this.playerPoToken = Objects.requireNonNull(playerPoToken, "playerPoToken");
+        if (this.visitorData.isEmpty()) {
+            throw new IllegalArgumentException("visitorData must not be empty");
+        }
+        if (this.playerPoToken.isEmpty()) {
+            throw new IllegalArgumentException("playerPoToken must not be empty");
+        }
+    }
+
+    @Nonnull
+    public String getVisitorData() {
+        return visitorData;
+    }
+
+    @Nonnull
+    public String getPlayerPoToken() {
+        return playerPoToken;
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrPlayerContextProvider.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrPlayerContextProvider.java
@@ -1,0 +1,32 @@
+package org.schabi.newpipe.extractor.services.youtube.sabr;
+
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
+/**
+ * Supplies route-affine player admission material as one atomic value.
+ */
+@FunctionalInterface
+public interface YoutubeSabrPlayerContextProvider {
+    /**
+     * Returns the current player admission context for a video and client profile.
+     */
+    @Nonnull
+    YoutubeSabrPlayerContext getPlayerContext(@Nonnull String videoId,
+                                              @Nonnull YoutubeSabrClientProfile profile)
+            throws IOException, ExtractionException;
+
+    /**
+     * Returns a fresh context when {@code forceRefresh} is true. The default implementation keeps
+     * compatibility with providers that do not cache their result.
+     */
+    @Nonnull
+    default YoutubeSabrPlayerContext getPlayerContext(
+            @Nonnull final String videoId,
+            @Nonnull final YoutubeSabrClientProfile profile,
+            final boolean forceRefresh) throws IOException, ExtractionException {
+        return getPlayerContext(videoId, profile);
+    }
+}

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrProbe.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrProbe.java
@@ -8,11 +8,13 @@ import com.grack.nanojson.JsonWriter;
 import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.downloader.StreamingResponse;
+import org.schabi.newpipe.extractor.exceptions.AntiBotException;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.ContentCountry;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeJavaScriptPlayerManager;
+import org.schabi.newpipe.extractor.services.youtube.YoutubePlayerResponseValidator;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper;
 import org.schabi.newpipe.extractor.utils.JsonUtils;
 
@@ -54,10 +56,57 @@ public final class YoutubeSabrProbe {
                                                 @Nullable final String playerPoToken,
                                                 @Nullable final String visitorDataOverride)
             throws IOException, ExtractionException {
+        return fetchSabrInfo(videoId, profile, localization, contentCountry, playerPoToken,
+                visitorDataOverride, null, false);
+    }
+
+    /**
+     * Fetches SABR metadata with one bounded player-context refresh when YouTube rejects the
+     * initial player admission request.
+     */
+    @Nonnull
+    public static YoutubeSabrInfo fetchSabrInfo(
+            @Nonnull final String videoId,
+            @Nonnull final YoutubeSabrClientProfile profile,
+            @Nonnull final Localization localization,
+            @Nonnull final ContentCountry contentCountry,
+            @Nonnull final YoutubeSabrPlayerContextProvider playerContextProvider)
+            throws IOException, ExtractionException {
+        YoutubeSabrPlayerContext playerContext = playerContextProvider.getPlayerContext(
+                videoId, profile, false);
+        try {
+            return fetchSabrInfo(videoId, profile, localization, contentCountry,
+                    playerContext.getPlayerPoToken(), playerContext.getVisitorData(),
+                    playerContextProvider, false);
+        } catch (final YoutubePlayerAdmissionException firstFailure) {
+            try {
+                playerContext = playerContextProvider.getPlayerContext(videoId, profile, true);
+                return fetchSabrInfo(videoId, profile, localization, contentCountry,
+                        playerContext.getPlayerPoToken(), playerContext.getVisitorData(),
+                        playerContextProvider, true);
+            } catch (final IOException | ExtractionException refreshedFailure) {
+                refreshedFailure.addSuppressed(firstFailure);
+                throw refreshedFailure;
+            }
+        }
+    }
+
+    @Nonnull
+    private static YoutubeSabrInfo fetchSabrInfo(
+            @Nonnull final String videoId,
+            @Nonnull final YoutubeSabrClientProfile profile,
+            @Nonnull final Localization localization,
+            @Nonnull final ContentCountry contentCountry,
+            @Nullable final String playerPoToken,
+            @Nullable final String visitorDataOverride,
+            @Nullable final YoutubeSabrPlayerContextProvider playerContextProvider,
+            final boolean playerContextRefreshed)
+            throws IOException, ExtractionException {
         final String cpn = YoutubeParsingHelper.generateContentPlaybackNonce();
         final JsonObject playerResponse = fetchPlayerResponse(videoId, profile, localization,
                 contentCountry, cpn, playerPoToken, visitorDataOverride);
-        return fromPlayerResponse(videoId, profile, cpn, playerResponse, visitorDataOverride);
+        return fromPlayerResponse(videoId, profile, cpn, playerResponse, visitorDataOverride,
+                playerPoToken, playerContextProvider, playerContextRefreshed);
     }
 
     @Nonnull
@@ -66,7 +115,8 @@ public final class YoutubeSabrProbe {
                                                      @Nonnull final String cpn,
                                                      @Nonnull final JsonObject playerResponse)
             throws ExtractionException {
-        return fromPlayerResponse(videoId, profile, cpn, playerResponse, null);
+        return fromPlayerResponse(videoId, profile, cpn, playerResponse, null, null, null,
+                false);
     }
 
     @Nonnull
@@ -74,8 +124,25 @@ public final class YoutubeSabrProbe {
                                                       @Nonnull final YoutubeSabrClientProfile profile,
                                                       @Nonnull final String cpn,
                                                       @Nonnull final JsonObject playerResponse,
-                                                      @Nullable final String visitorDataOverride)
+                                                      @Nullable final String visitorDataOverride,
+                                                      @Nullable final String playerPoToken,
+                                                      @Nullable final YoutubeSabrPlayerContextProvider
+                                                              playerContextProvider,
+                                                      final boolean playerContextRefreshed)
             throws ExtractionException {
+        final JsonObject playabilityStatus = playerResponse.getObject("playabilityStatus");
+        if (playabilityStatus != null) {
+            try {
+                YoutubePlayerResponseValidator.checkPlayabilityStatus(playabilityStatus);
+            } catch (final AntiBotException e) {
+                final String status = playabilityStatus.getString("status", "UNKNOWN");
+                final String reason = playabilityStatus.getString("reason", e.getMessage());
+                throw new YoutubePlayerAdmissionException(videoId, profile, status, reason,
+                        playerPoToken != null && !playerPoToken.isEmpty(),
+                        visitorDataOverride != null && !visitorDataOverride.isEmpty(),
+                        playerContextRefreshed, e);
+            }
+        }
         final JsonObject streamingData = playerResponse.getObject(STREAMING_DATA);
         if (streamingData == null) {
             throw new SabrProtocolException("Player response has no streamingData for " + profile);
@@ -91,7 +158,8 @@ public final class YoutubeSabrProbe {
 
         return new YoutubeSabrInfo(profile, videoId, cpn, resolveClientVersion(profile),
                 visitorData, serverAbrStreamingUrl, ustreamerConfig,
-                YoutubeSabrFormat.fromAdaptiveFormats(videoId, adaptiveFormats));
+                YoutubeSabrFormat.fromAdaptiveFormats(videoId, adaptiveFormats),
+                playerContextProvider, playerPoToken);
     }
 
     @Nonnull

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrRequestBuilder.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrRequestBuilder.java
@@ -393,9 +393,10 @@ final class YoutubeSabrRequestBuilder {
                                                @Nullable final YoutubeSabrStreamState streamState) {
         final SabrProto.Writer context = new SabrProto.Writer();
         context.writeMessage(1, buildClientInfo(info, streamState));
-        final byte[] poToken = streamState == null ? null : streamState.getRawPoToken();
-        if (poToken != null && poToken.length > 0) {
-            context.writeBytes(2, poToken);
+        final byte[] contentPoToken = streamState == null
+                ? null : streamState.getRawContentPoToken();
+        if (contentPoToken != null && contentPoToken.length > 0) {
+            context.writeBytes(2, contentPoToken);
         }
         if (playbackCookie != null && playbackCookie.length > 0) {
             context.writeBytes(3, playbackCookie);

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrSession.java
@@ -266,8 +266,8 @@ public final class YoutubeSabrSession {
         addDiagnosticEvent("request n=" + requestNumber
                 + " playerMs=" + streamState.getRequestPlayerTimeMs()
                 + " edgeMs=" + streamState.getMinBufferedEndMs()
-                + " poTokenBytes=" + (streamState.getRawPoToken() == null
-                ? -1 : streamState.getRawPoToken().length)
+                + " contentPoTokenBytes=" + (streamState.getRawContentPoToken() == null
+                ? -1 : streamState.getRawContentPoToken().length)
                 + " ranges=" + streamState.summarizeBufferedRanges());
         final long requestStartNs = System.nanoTime();
         final SabrStreamingResponseReader.StoppableSegmentConsumer timedConsumer =
@@ -415,8 +415,19 @@ public final class YoutubeSabrSession {
         final ContentCountry contentCountry = localization.getCountryCode().isEmpty()
                 ? ContentCountry.DEFAULT
                 : new ContentCountry(localization.getCountryCode());
-        final YoutubeSabrInfo fresh = YoutubeSabrProbe.fetchSabrInfo(
-                info.getVideoId(), info.getProfile(), localization, contentCountry);
+        final YoutubeSabrPlayerContextProvider playerContextProvider =
+                info.getPlayerContextProvider();
+        final YoutubeSabrInfo fresh;
+        if (playerContextProvider != null) {
+            fresh = YoutubeSabrProbe.fetchSabrInfo(info.getVideoId(), info.getProfile(),
+                    localization, contentCountry, playerContextProvider);
+        } else if (info.getPlayerPoToken() != null || info.getVisitorData() != null) {
+            fresh = YoutubeSabrProbe.fetchSabrInfo(info.getVideoId(), info.getProfile(),
+                    localization, contentCountry, info.getPlayerPoToken(), info.getVisitorData());
+        } else {
+            fresh = YoutubeSabrProbe.fetchSabrInfo(info.getVideoId(), info.getProfile(),
+                    localization, contentCountry);
+        }
         if (fresh.getServerAbrStreamingUrl() == null || fresh.getServerAbrStreamingUrl().isEmpty()) {
             return false;
         }
@@ -1363,13 +1374,13 @@ public final class YoutubeSabrSession {
         if (poTokenProvider == null) {
             return false;
         }
-        final byte[] current = streamState.getRawPoToken();
+        final byte[] current = streamState.getRawContentPoToken();
         if (current != null && current.length > 0 && !forceRefresh) {
             return false;
         }
         final byte[] poToken = poTokenProvider.getPoToken(info, streamState, forceRefresh);
         if (poToken != null && poToken.length > 0 && !Arrays.equals(poToken, current)) {
-            streamState.setPoToken(poToken);
+            streamState.setContentPoToken(poToken);
             return true;
         }
         return false;

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrStreamState.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/sabr/YoutubeSabrStreamState.java
@@ -25,7 +25,7 @@ public final class YoutubeSabrStreamState {
     @Nullable
     private byte[] playbackCookie;
     @Nullable
-    private byte[] poToken;
+    private byte[] contentPoToken;
     @Nullable
     private volatile SabrNextRequestPolicy nextRequestPolicy;
     private long playerTimeMsOverride = -1;
@@ -234,13 +234,30 @@ public final class YoutubeSabrStreamState {
         return playbackCookie == null ? null : playbackCookie.clone();
     }
 
-    public void setPoToken(@Nullable final byte[] poToken) {
-        this.poToken = poToken == null ? null : poToken.clone();
+    public void setContentPoToken(@Nullable final byte[] contentPoToken) {
+        this.contentPoToken = contentPoToken == null ? null : contentPoToken.clone();
     }
 
     @Nullable
+    public byte[] getContentPoToken() {
+        return contentPoToken == null ? null : contentPoToken.clone();
+    }
+
+    /**
+     * @deprecated use {@link #setContentPoToken(byte[])}
+     */
+    @Deprecated
+    public void setPoToken(@Nullable final byte[] poToken) {
+        setContentPoToken(poToken);
+    }
+
+    /**
+     * @deprecated use {@link #getContentPoToken()}
+     */
+    @Nullable
+    @Deprecated
     public byte[] getPoToken() {
-        return poToken == null ? null : poToken.clone();
+        return getContentPoToken();
     }
 
     @Nullable
@@ -249,8 +266,8 @@ public final class YoutubeSabrStreamState {
     }
 
     @Nullable
-    byte[] getRawPoToken() {
-        return poToken;
+    byte[] getRawContentPoToken() {
+        return contentPoToken;
     }
 
     @Nonnull


### PR DESCRIPTION
# fix(youtube): refresh rejected SABR player contexts

## Summary

While investigating current WEB and MWEB player responses that return `LOGIN_REQUIRED` before exposing any `streamingData`, I found that the SABR path was treating two different PO-token roles as if they were one piece of state.

The Innertube `/player` request needs a visitor/session-bound PO token sent through `serviceIntegrityDimensions.poToken`. That token has to stay attached to the `visitorData` from the same player context. The later SABR media requests use a different, video ID-bound token in `StreamerContext` field 2.

The extractor already accepted raw player token and visitor values for the initial probe, but it could not refresh them after YouTube rejected the player request. A later SABR session reload also called the anonymous probe overload and silently discarded the context that had admitted the original request.

This hotfix keeps both token roles separate, preserves the player context across SABR reloads and adds one bounded refresh when YouTube explicitly rejects player admission as bot verification.

## Problem

The failure happens before the SABR protocol starts:

```text
WEB/MWEB /player
playabilityStatus.status = LOGIN_REQUIRED
reason = Sign in to confirm you are not a bot
streamingData = absent
serverAbrStreamingUrl = absent
```

The SABR probe previously checked for `streamingData` first, so this became a generic protocol error. The caller could not distinguish an expired or rejected player context from a malformed SABR response.

There were also two recovery problems:

- the raw `visitorData` and player PO token had no refresh contract;
- `YoutubeSabrSession` reloaded metadata anonymously, even when the session had originally been opened with valid player admission material.

Refreshing only one value is not sufficient. The visitor data and player PO token are route-affine and must be replaced together. Reusing the video ID-bound SABR media token for `/player` is also invalid because it has a different binding and wire role.

Without an extractor-level distinction, downstream callers either lose the original session context or have to recover around a generic missing-`streamingData` error.

## Changes

- Move the existing YouTube playability mapping into a shared player-response validator so normal stream extraction and SABR use the same private, age-restricted, paid, members-only, scheduled and anti-bot classifications.
- Recognize the bot-verification response from both its current English reason and the stable structured help endpoint, so localized WEB/MWEB responses remain classifiable.
- Add `YoutubePlayerAdmissionException` with the rejected client profile, playability status and non-sensitive context-presence diagnostics.
- Add `YoutubeSabrPlayerContext` to keep `visitorData` and its player PO token as one atomic value.
- Add `YoutubeSabrPlayerContextProvider` so callers can supply the current context and explicitly refresh it when rejected.
- Retry `/player` exactly once after an admission rejection, then preserve both failures if the refreshed request or provider still fails.
- Retain the provider and raw player context in `YoutubeSabrInfo` for metadata reloads.
- Keep provider and player-token references transient so they are not written when SABR info is serialized.
- Preserve the original anonymous and raw-value probe overloads for existing callers.
- Rename the internal SABR media token state to `contentPoToken` and document that it belongs only in `StreamerContext`.
- Keep `setPoToken` and `getPoToken` as deprecated compatibility aliases.

## Recovery behavior

The provider-backed flow is now bounded:

```text
1. Request the current visitorData + player PO token pair.
2. Call WEB/MWEB /player with both values.
3. If player admission succeeds, continue with the normal SABR flow.
4. If YouTube returns the bot-verification admission error, request one fresh pair.
5. Retry /player once with the fresh pair.
6. Return the refreshed result or surface the final typed failure.
```

## Compatibility

Existing callers can continue using the anonymous probe or the overload that accepts raw player values. Existing `YoutubeSabrStreamState#setPoToken` and `getPoToken` calls also continue to work.

Automatic admission refresh is available only through `YoutubeSabrPlayerContextProvider`, because the extractor cannot mint or renew caller-owned BotGuard material by itself.

The SABR request wire format is unchanged. `StreamerContext` field 2 still carries the video ID-bound media token; the change makes that role explicit and prevents it from being confused with the `/player` token.

## Validation

Build:

- `./gradlew clean build`
- `git diff --check`

Local admission harness using captured official WEB and MWEB player responses:

- classified the captured `LOGIN_REQUIRED` responses before the generic missing-`streamingData` path;
- classified the same response after replacing the English message with localized text;
- sent the stale visitor/token pair together on the first request;
- requested one forced refresh and sent the fresh pair together on the second request;
- returned SABR metadata after the refreshed player response succeeded;
- stopped after exactly two rejected player requests;
- retained the original admission failure when the refreshed request failed;
- retained the original admission failure when the provider itself failed during refresh;
- preserved the provider in memory for SABR metadata reloads;
- confirmed that the provider and raw player token are not serialized;
- confirmed that the legacy raw-value overload retains its context for reloads.


## Notes

This change does not make PipePipeExtractor responsible for BotGuard execution or token minting. It defines the missing player-admission boundary: callers provide one atomic context, and the extractor knows when and how often that context may be refreshed.

The media-token provider remains separate because a token bound to the video ID cannot replace the visitor/session-bound token required by `/player`.
