### PR TITLE
fix(youtube): expose upload dates for Shorts

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/YoutubeParsingHelper.java
@@ -1528,6 +1528,27 @@ YoutubeParsingHelper {
         // @formatter:on
     }
 
+    public static JsonBuilder<JsonObject> prepareTvHtml5JsonBuilder(
+            @Nonnull final Localization localization,
+            @Nonnull final ContentCountry contentCountry) {
+        // @formatter:off
+        return JsonObject.builder()
+                .object("context")
+                .object("client")
+                .value("clientName", TVHTML5_CLIENT_NAME)
+                .value("clientVersion", TVHTML5_CLIENT_VERSION)
+                .value("platform", TVHTML5_CLIENT_PLATFORM)
+                .value("deviceMake", TVHTML5_DEVICE_MAKE)
+                .value("deviceModel", TVHTML5_DEVICE_MODEL_AND_OS_NAME)
+                .value("osName", TVHTML5_DEVICE_MODEL_AND_OS_NAME)
+                .value("hl", localization.getLocalizationCode())
+                .value("gl", contentCountry.getCountryCode())
+                .value("utcOffsetMinutes", 0)
+                .end()
+                .end();
+        // @formatter:on
+    }
+
     @Nonnull
     public static JsonBuilder<JsonObject> prepareJsonPlayerBuilder(
             @Nonnull final Localization localization,

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeChannelTabExtractor.java
@@ -29,8 +29,13 @@ import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.YOUTUBEI_V1_URL;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.addYoutubeHeaders;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getChannelResponse;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonAndroidPostResponse;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getJsonPostResponse;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getTextFromObject;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.getValidJsonResponseBody;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareAndroidMobileJsonBuilder;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareDesktopJsonBuilder;
+import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.prepareTvHtml5JsonBuilder;
 import static org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper.resolveChannelId;
 import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
 
@@ -47,6 +52,7 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
     @Nullable
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     protected Optional<YoutubeChannelHelper.ChannelHeader> channelHeader;
+    private Map<String, String> shortsUploadDates = Collections.emptyMap();
 
     public YoutubeChannelTabExtractor(final StreamingService service,
                                       final ListLinkHandler linkHandler) {
@@ -133,14 +139,27 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
         Page nextPage = null;
 
         if (getTabData() != null) {
-            final JsonArray items = getSelectedSortFilterIndex() > 0
-                    ? getSortedItemsFrom(tabData)
+            final int sortFilterIndex = getSelectedSortFilterIndex();
+            String sortContinuation = null;
+            if (sortFilterIndex > 0) {
+                sortContinuation = getSortContinuationToken(tabData);
+            } else if (useVisitorData) {
+                try {
+                    sortContinuation = getSortContinuationToken(tabData);
+                } catch (final ParsingException ignored) {
+                    // Small channels may not expose sort chips. Their generated Shorts playlist
+                    // is used as the upload-date fallback below.
+                }
+            }
+            final JsonArray items = sortFilterIndex > 0
+                    ? getSortedItemsFrom(sortContinuation)
                     : getInitialItemsFrom(tabData);
 
             final List<String> channelIds = new ArrayList<>();
             channelIds.add(getChannelName());
             channelIds.add(YoutubeChannelLinkHandlerFactory.getInstance()
                     .getUrl("channel/" + getId()));
+            shortsUploadDates = fetchShortsUploadDates(sortContinuation, getId());
             final JsonObject continuation = collectItemsFrom(collector, items, channelIds);
 
             nextPage = getNextPageFrom(continuation, channelIds);
@@ -171,11 +190,11 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
     }
 
     @Nonnull
-    private JsonArray getSortedItemsFrom(@Nonnull final JsonObject currentTabData)
+    private JsonArray getSortedItemsFrom(@Nonnull final String continuation)
             throws IOException, ExtractionException {
         final byte[] body = JsonWriter.string(prepareDesktopJsonBuilder(getExtractorLocalization(),
                         getExtractorContentCountry())
-                        .value("continuation", getSortContinuationToken(currentTabData))
+                        .value("continuation", continuation)
                         .done())
                 .getBytes(StandardCharsets.UTF_8);
 
@@ -327,8 +346,11 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
 
         final JsonObject ajaxJson = JsonUtils.toJsonObject(getValidJsonResponseBody(response));
 
-        final JsonObject continuation = collectItemsFrom(collector,
-                getContinuationItemsFrom(ajaxJson, "appendContinuationItemsAction"), channelIds);
+        final JsonArray continuationItems = getContinuationItemsFrom(
+                ajaxJson, "appendContinuationItemsAction");
+        shortsUploadDates = fetchShortsUploadDates(getContinuationFromPage(page), null);
+        final JsonObject continuation = collectItemsFrom(
+                collector, continuationItems, channelIds);
         if (ServiceList.YouTube.getFilterTypes().contains("channels")) {
             collector.applyBlocking(ServiceList.YouTube.getFilterConfig());
         }
@@ -502,8 +524,11 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
             } else if (richItem.has("reelItemRenderer")) {
                 commitVideo.accept(richItem.getObject("reelItemRenderer"));
             } else if (richItem.has("shortsLockupViewModel")) {
+                final JsonObject shortsLockupViewModel = richItem.getObject(
+                        "shortsLockupViewModel");
+                final String videoId = getShortsVideoId(shortsLockupViewModel);
                 collector.commit(new YoutubeShortsInfoItemExtractor(
-                        richItem.getObject("shortsLockupViewModel")
+                        shortsLockupViewModel, shortsUploadDates.get(videoId), getTimeAgoParser()
                 ) {
                     @Override
                     public String getUploaderName() {
@@ -555,6 +580,139 @@ public class YoutubeChannelTabExtractor extends ChannelTabExtractor {
                     item.getObject("lockupViewModel"), channelIds);
         }
         return null;
+    }
+
+    /**
+     * The WEB client omits upload dates from Shorts cards. For regular channels, replaying the
+     * exact sort or page continuation with TVHTML5 returns dated tile renderers. Small channels
+     * without sort chips use their generated {@code UUSH} playlist through the Android client.
+     * Dates from either response are associated with the WEB items by video ID.
+     */
+    @Nonnull
+    private Map<String, String> fetchShortsUploadDates(
+            @Nullable final String continuation,
+            @Nullable final String currentChannelId) {
+        if (!useVisitorData) {
+            return Collections.emptyMap();
+        }
+
+        try {
+            final Map<String, String> uploadDates = new HashMap<>();
+            if (!isNullOrEmpty(continuation)) {
+                final byte[] body = JsonWriter.string(prepareTvHtml5JsonBuilder(
+                                getExtractorLocalization(), getExtractorContentCountry())
+                                .value("continuation", continuation)
+                                .done())
+                        .getBytes(StandardCharsets.UTF_8);
+                collectShortsUploadDates(getJsonPostResponse(
+                        "browse", body, getExtractorLocalization()), uploadDates);
+            } else if (!isNullOrEmpty(currentChannelId) && currentChannelId.startsWith("UC")) {
+                final byte[] body = JsonWriter.string(prepareAndroidMobileJsonBuilder(
+                                getExtractorLocalization(), getExtractorContentCountry(),
+                                visitorData == null ? "" : visitorData)
+                                .value("playlistId", "UUSH" + currentChannelId.substring(2))
+                                .done())
+                        .getBytes(StandardCharsets.UTF_8);
+                collectShortsUploadDates(getJsonAndroidPostResponse(
+                        "next", body, getExtractorLocalization(), null), uploadDates);
+            }
+            return uploadDates;
+        } catch (final IOException | ExtractionException ignored) {
+            return Collections.emptyMap();
+        }
+    }
+
+    private void collectShortsUploadDates(@Nonnull final Object object,
+                                          @Nonnull final Map<String, String> uploadDates) {
+        if (object instanceof JsonObject) {
+            final JsonObject jsonObject = (JsonObject) object;
+            if (jsonObject.has("tileRenderer")) {
+                final JsonObject tileRenderer = jsonObject.getObject("tileRenderer");
+                final String videoId = tileRenderer.getString("contentId");
+                final String uploadDate = getTileUploadDate(tileRenderer);
+                if (!isNullOrEmpty(videoId) && !isNullOrEmpty(uploadDate)) {
+                    uploadDates.put(videoId, uploadDate);
+                }
+            } else if (jsonObject.has("playlistPanelVideoRenderer")) {
+                final JsonObject videoRenderer = jsonObject.getObject(
+                        "playlistPanelVideoRenderer");
+                final String videoId = videoRenderer.getString("videoId");
+                final String uploadDate = getPlaylistPanelUploadDate(videoRenderer);
+                if (!isNullOrEmpty(videoId) && !isNullOrEmpty(uploadDate)) {
+                    uploadDates.put(videoId, uploadDate);
+                }
+            }
+
+            for (final Object value : jsonObject.values()) {
+                collectShortsUploadDates(value, uploadDates);
+            }
+        } else if (object instanceof JsonArray) {
+            for (final Object value : (JsonArray) object) {
+                collectShortsUploadDates(value, uploadDates);
+            }
+        }
+    }
+
+    @Nullable
+    private String getTileUploadDate(@Nonnull final JsonObject tileRenderer) {
+        final JsonArray lines = tileRenderer
+                .getObject("metadata")
+                .getObject("tileMetadataRenderer")
+                .getArray("lines");
+        for (final Object line : lines) {
+            final JsonArray items = ((JsonObject) line)
+                    .getObject("lineRenderer")
+                    .getArray("items");
+            for (final Object item : items) {
+                try {
+                    final String text = getTextFromObject(((JsonObject) item)
+                            .getObject("lineItemRenderer")
+                            .getObject("text"));
+                    if (!isNullOrEmpty(text)) {
+                        getTimeAgoParser().parse(text);
+                        return text;
+                    }
+                } catch (final Exception ignored) {
+                }
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private String getPlaylistPanelUploadDate(@Nonnull final JsonObject videoRenderer) {
+        for (final Object run : videoRenderer.getObject("videoInfo").getArray("runs")) {
+            final String text = ((JsonObject) run).getString("text");
+            try {
+                getTimeAgoParser().parse(text);
+                return text;
+            } catch (final Exception ignored) {
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    private String getContinuationFromPage(@Nonnull final Page page) {
+        if (page.getBody() == null) {
+            return null;
+        }
+        try {
+            return JsonUtils.toJsonObject(new String(page.getBody(), StandardCharsets.UTF_8))
+                    .getString("continuation");
+        } catch (final Exception ignored) {
+            return null;
+        }
+    }
+
+    @Nullable
+    private String getShortsVideoId(@Nonnull final JsonObject shortsLockupViewModel) {
+        final String videoId = shortsLockupViewModel
+                .getObject("onTap")
+                .getObject("innertubeCommand")
+                .getObject("reelWatchEndpoint")
+                .getString("videoId");
+        return isNullOrEmpty(videoId) ? null : videoId;
     }
 
     @Nullable

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeShortsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/youtube/extractors/YoutubeShortsInfoItemExtractor.java
@@ -3,17 +3,33 @@ package org.schabi.newpipe.extractor.services.youtube.extractors;
 import com.grack.nanojson.JsonObject;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.localization.DateWrapper;
+import org.schabi.newpipe.extractor.localization.TimeAgoParser;
 import org.schabi.newpipe.extractor.stream.StreamInfoItemExtractor;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nullable;
 
+import static org.schabi.newpipe.extractor.utils.Utils.isNullOrEmpty;
+
 public class YoutubeShortsInfoItemExtractor implements StreamInfoItemExtractor {
     public JsonObject item;
-    public YoutubeShortsInfoItemExtractor(JsonObject item) {
-        this.item = item;
+    @Nullable
+    private final String textualUploadDate;
+    private final TimeAgoParser timeAgoParser;
+
+    public YoutubeShortsInfoItemExtractor(final JsonObject item) {
+        this(item, null, null);
     }
+
+    public YoutubeShortsInfoItemExtractor(final JsonObject item,
+                                          @Nullable final String textualUploadDate,
+                                          @Nullable final TimeAgoParser timeAgoParser) {
+        this.item = item;
+        this.textualUploadDate = textualUploadDate;
+        this.timeAgoParser = timeAgoParser;
+    }
+
     @Override
     public String getName() throws ParsingException {
         return item.getObject("overlayMetadata").getObject("primaryText").getString("content");
@@ -65,12 +81,16 @@ public class YoutubeShortsInfoItemExtractor implements StreamInfoItemExtractor {
     @Nullable
     @Override
     public String getTextualUploadDate() throws ParsingException {
-        return null;
+        return textualUploadDate;
     }
 
     @Nullable
     @Override
     public DateWrapper getUploadDate() throws ParsingException {
-        return null;
+        final String textualUploadDate = getTextualUploadDate();
+        if (timeAgoParser == null || isNullOrEmpty(textualUploadDate)) {
+            return null;
+        }
+        return timeAgoParser.parse(textualUploadDate);
     }
 }


### PR DESCRIPTION
Closes #90.

## Context

The current WEB channel response still omits the upload date from `shortsLockupViewModel`. The `uploadTimeFactoidRenderer` structure discussed in #2393 is not present in the current channel API response, so reading it directly from the WEB card does not fix the live app.

## Implementation

The WEB response remains authoritative for the Shorts content, order and pagination.

For each Shorts page:

- when a sort or page continuation is available, the exact same token is replayed with TVHTML5, which returns dated `tileRenderer` items;
- dates are associated with the WEB items by `videoId`, never by their position in the response;
- small channels without sort chips use their generated `UUSH` Shorts playlist through the Android client, then dates are also mapped by `videoId`;
- the resulting relative date is exposed by `YoutubeShortsInfoItemExtractor` and parsed with the existing localized `TimeAgoParser`.

The additional request is best effort. If YouTube rejects it, times out or changes the alternate response, the original Shorts page still works and simply has no upload dates. There is one additional request per Shorts page, not one request per item.

Non-Shorts tabs are unchanged, and the existing `YoutubeShortsInfoItemExtractor(JsonObject)` constructor remains available.

## Client impact

PipePipe Client already displays and persists the Extractor upload date fields. No production Client change or database migration is required.

## Validation

- full Extractor test suite;
- PipePipe Client debug compilation against this exact local Extractor;
- live extraction on large and small channels;
- Latest, Popular and Oldest sorting, including continuation pages;
- English, French, Japanese and Arabic date parsing;
- simulated TVHTML5 and Android request failures;
- manual PipePipe check on Android 16, including scrolling into a continuation page.

No test file is included in this PR, as requested.
